### PR TITLE
rrule to text transformation fix

### DIFF
--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -35,7 +35,7 @@ class TextTransformer
         $count = $rule->getCount();
         if ($until instanceof \DateTime) {
             $this->addFragment('until');
-            $this->addFragment(strftime('%B %#d, %Y', $until->getTimestamp()));
+            $this->addFragment($until->format('F j, Y'));
         } else if (!empty($count)) {
             $this->addFragment('for');
             $this->addFragment($count);
@@ -254,7 +254,7 @@ class TextTransformer
 
         $byMonth = array_map(
             function ($monthInt) {
-                return strftime('%B', mktime(1, 1, 1, $monthInt, 1));
+                return date('F', mktime(1, 1, 1, $monthInt, 1));
             },
             $byMonth
         );
@@ -280,7 +280,7 @@ class TextTransformer
 
         $timestamp = mktime(1, 1, 1, 1, 12, 2014); // A Sunday
         foreach (array_keys($map) as $short) {
-            $long        = strftime('%A', $timestamp);
+            $long        = date('l', $timestamp);
             $map[$short] = $long;
             $timestamp += 86400;
         }


### PR DESCRIPTION
My guess you use Windows platform for development that's why there is a **%#d** format used for [strftime](http://ca1.php.net/manual/en/function.strftime.php). Anyways, this test isn't passed on Linux even if I change **%#d** to **%e**. 

What was your intention, to leave a whitespace or not before 1 digit day number? Because your test clearly tells that NOT, but the code tells the OPPOSITE. 

As I don't see any benefit for leaving a whitespace and considering `$until` is a `DateTime` object as it is, I prefer to use `DateTime::format` method. 
