### PR TITLE
Fixed simshaun/recurr#27: Fatal error: Uncaught exception 'Exception' with message 'DateTime::__construct() expects parameter 1 to be string, object given' in .../vendor/simshaun/recurr/src/Recurr/Rule.php:1072

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -1067,14 +1067,14 @@ class Rule
         foreach ($exDates as $key => $val) {
             if ($val instanceof DateExclusion) {
                 $val->date = $this->convertZtoUtc($val->date);
+            } else {
+                $date          = new \DateTime($val, $timezone);
+                $exDates[$key] = new DateExclusion(
+                    $this->convertZtoUtc($date),
+                    strpos($val, 'T') !== false,
+                    strpos($val, 'Z') !== false
+                );
             }
-
-            $date          = new \DateTime($val, $timezone);
-            $exDates[$key] = new DateExclusion(
-                $this->convertZtoUtc($date),
-                strpos($val, 'T') !== false,
-                strpos($val, 'Z') !== false
-            );
         }
 
         $this->exDates = $exDates;

--- a/tests/Recurr/Test/Transformer/ArrayTransformerExDateTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerExDateTest.php
@@ -3,9 +3,33 @@
 namespace Recurr\Test\Transformer;
 
 use Recurr\Rule;
+use Recurr\DateExclusion;
 
 class ArrayTransformerExDateTest extends ArrayTransformerBase
 {
+
+    /**
+     * Original timezone. Restore it upon test suite completion!
+     *
+     * @var string
+     */
+    protected static $originalTimezoneName;
+
+    public static function setUpBeforeClass()
+    {
+        self::$originalTimezoneName = date_default_timezone_get();
+        date_default_timezone_set('America/New_York');
+
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        date_default_timezone_set(self::$originalTimezoneName);
+
+        parent::tearDownAfterClass();
+    }
+
     public function testExDateNoTime()
     {
         $rule = new Rule(
@@ -64,4 +88,26 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         $this->assertCount(1, $computed);
         $this->assertEquals(new \DateTime('2014-06-03 04:00:00', $timezone), $computed[0]->getStart());
     }
+
+    /**
+     * @test
+     */
+    public function setExDates()
+    {
+        $rule    = new Rule(
+            'FREQ=DAILY;COUNT=3',
+            new \DateTime('2014-06-01')
+        );
+        $exDates = array(
+            new DateExclusion(new \DateTime('2014-06-02'), false),
+        );
+        $rule->setExDates($exDates);
+
+        $computed = $this->transformer->transform($rule);
+
+        $this->assertCount(2, $computed);
+        $this->assertEquals(new \DateTime('2014-06-01'), $computed[0]->getStart());
+        $this->assertEquals(new \DateTime('2014-06-03'), $computed[1]->getStart());
+    }
+
 }


### PR DESCRIPTION
Didn't wade through all these commits squashing thing from different branches, so finally created a new pull request. 
