### PR TITLE
Make TextTransformer translateable

### DIFF
--- a/src/Recurr/Transformer/Translator.php
+++ b/src/Recurr/Transformer/Translator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Recurr\Transformer;
+
+class Translator implements TranslatorInterface
+{
+    protected $data = array();
+
+    public function __construct($locale = 'en', $fallbackLocale = 'en')
+    {
+        $this->loadLocale($fallbackLocale);
+        if ($locale !== $fallbackLocale) {
+            $this->loadLocale($locale);
+        }
+    }
+
+    public function loadLocale($locale, $path = null)
+    {
+        if (!$path) {
+            $path = __DIR__ . '/../../../translations/' . $locale . '.php';
+        }
+        if (!file_exists($path)) {
+            throw new \InvalidArgumentException('Locale '.$locale.' could not be found in '.$path);
+        }
+
+        $this->data = array_merge($this->data, include $path);
+    }
+
+    public function trans($string, array $params = array())
+    {
+        $res = $this->data[$string];
+        if (is_object($res) && is_callable($res)) {
+            $res = $res($string, $params);
+        }
+
+        foreach ($params as $key => $val) {
+            $res = str_replace('%' . $key . '%', $val, $res);
+        }
+
+        return $res;
+    }
+}

--- a/src/Recurr/Transformer/TranslatorInterface.php
+++ b/src/Recurr/Transformer/TranslatorInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Recurr\Transformer;
+
+interface TranslatorInterface
+{
+    public function trans($string);
+}

--- a/translations/de.php
+++ b/translations/de.php
@@ -1,0 +1,33 @@
+<?php
+
+return array(
+    'Unable to fully convert this rrule to text.' => 'RRule kann nicht vollständig zu Text konvertiert werden.',
+    'for %count% times' => '%count% Mal',
+    'for %count% time' => '%count% Mal',
+    '(~ approximate)' => '(~ ungefähr)',
+    'until %date%' => 'bis %date%', // e.g. every year until July 4, 2014
+    'day_date' => defined('PHP_WINDOWS_VERSION_BUILD') ? '%#d. %B, %Y' : '%e. %B, %Y',
+    'and' => 'und',
+    'or' => 'oder',
+    'in' => 'im', // e.g. every week in January, May and August
+    'on' => 'am', // e.g. every day on Tuesday, Wednesday and Friday
+    'the' => 'das',
+    'on the' => 'am', // e.g. every year on the 1st and 200th day
+    'every %count% years' => 'alle %count% Jahre',
+    'every year' => 'jedes Jahr',
+    'every_month_list' => 'jeden', // e.g. every January, May and August
+    'every %count% months' => 'alle %count% Monate',
+    'every month' => 'jeden Monat',
+    'every %count% weeks' => 'alle %count% Wochen',
+    'every week' => 'jede Woche',
+    'every %count% days' => 'alle %count% Tage',
+    'every day' => 'jeden Tag',
+    'last' => 'letzte', // e.g. 2nd last Friday
+    'days' => 'Tage',
+    'day' => 'Tag',
+    'weeks' => 'Wochen',
+    'week' => 'Woche',
+    'ordinal_number' => function ($str, $params) { // formats a number with a prefix e.g. every year on the 1st and 200th day
+        return $params['number'] . '.';
+    },
+);

--- a/translations/en.php
+++ b/translations/en.php
@@ -1,0 +1,43 @@
+<?php
+
+return array(
+    'Unable to fully convert this rrule to text.' => 'Unable to fully convert this rrule to text.',
+    'for %count% times' => 'for %count% times',
+    'for %count% time' => 'for %count% time',
+    '(~ approximate)' => '(~ approximate)',
+    'until %date%' => 'until %date%', // e.g. every year until July 4, 2014
+    'day_date' => defined('PHP_WINDOWS_VERSION_BUILD') ? '%B %#d, %Y' : '%B %e, %Y',
+    'and' => 'and',
+    'or' => 'or',
+    'in' => 'in', // e.g. every week in January, May and August
+    'on' => 'on', // e.g. every day on Tuesday, Wednesday and Friday
+    'the' => 'the',
+    'on the' => 'on the', // e.g. every year on the 1st and 200th day
+    'every %count% years' => 'every %count% years',
+    'every year' => 'every year',
+    'every_month_list' => 'every', // e.g. every January, May and August
+    'every %count% months' => 'every %count% months',
+    'every month' => 'every month',
+    'every %count% weeks' => 'every %count% weeks',
+    'every week' => 'every week',
+    'every %count% days' => 'every %count% days',
+    'every day' => 'every day',
+    'last' => 'last', // e.g. 2nd last Friday
+    'days' => 'days',
+    'day' => 'day',
+    'weeks' => 'weeks',
+    'week' => 'week',
+    'ordinal_number' => function ($str, $params) { // formats a number with a prefix e.g. every year on the 1st and 200th day
+        $number = $params['number'];
+
+        $ends = array('th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th');
+
+        if (($number % 100) >= 11 && ($number % 100) <= 13) {
+            $abbreviation = $number.'th';
+        } else {
+            $abbreviation = $number.$ends[$number % 10];
+        }
+
+        return $abbreviation;
+    },
+);

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -1,0 +1,39 @@
+<?php
+
+return array(
+    'Unable to fully convert this rrule to text.' => 'Cette règle de récurrence n\'a pas pu être convertie en texte.',
+    'for %count% times' => '%count% fois',
+    'for %count% time' => '%count% fois',
+    '(~ approximate)' => '(~ approximation)',
+    'until %date%' => 'jusqu\'au %date%', // e.g. every year until July 4, 2014
+    'day_date' => defined('PHP_WINDOWS_VERSION_BUILD') ? '%#d %B, %Y' : '%e %B, %Y',
+    'and' => 'et',
+    'or' => 'ou',
+    'in' => 'en', // e.g. every week in January, May and August
+    'on' => 'le', // e.g. every day on Tuesday, Wednesday and Friday
+    'the' => 'le',
+    'on the' => 'le', // e.g. every year on the 1st and 200th day
+    'every %count% years' => 'tous les %count% ans',
+    'every year' => 'chaque année',
+    'every_month_list' => 'chaque', // e.g. every January, May and August
+    'every %count% months' => 'tous les %count% mois',
+    'every month' => 'chaque mois',
+    'every %count% weeks' => 'toutes les %count% semaines',
+    'every week' => 'chaque semaine',
+    'every %count% days' => 'tous les %count% jours',
+    'every day' => 'chaque jour',
+    'last' => 'dernier', // e.g. 2nd last Friday
+    'days' => 'jours',
+    'day' => 'jour',
+    'weeks' => 'semaines',
+    'week' => 'semaine',
+    'ordinal_number' => function ($str, $params) { // formats a number with a prefix e.g. every year on the 1st and 200th day
+        $number = $params['number'];
+
+        if ($number == 1) {
+            return $number.'er';
+        }
+
+        return $number.'ème';
+    },
+);


### PR DESCRIPTION
This fixes #43 and allows providing a translator to the TextTransformer.

By default it works fully BC and will continue to output english texts. But if you provide a configured translator with the right locale you can get texts in french or german (so far the only two I did as proof of concept that this works with more than english).

Combined with a `setlocale(LC_ALL, 'de');` for example it will also output the month/day names in the right language. I am not sure if we really want to do that or include month and day in the translation so that it is fully self-contained? setlocale can be a bit of a pain to work with depending on the system and not all locales are supported on all machines AFAIK. I am happy to do that additional change if deemed necessary.
