### PR TITLE
Fix for leapyearbug test

### DIFF
--- a/src/Recurr/DateUtil.php
+++ b/src/Recurr/DateUtil.php
@@ -442,12 +442,8 @@ class DateUtil
 
     public static function hasLeapYearBug()
     {
-        $leapBugTest = \DateTime::createFromFormat('z Y', '80 2016');
-        if ($leapBugTest->format('Y-m-d') == '2016-03-22') {
-            return true;
-        }
-
-        return false;
+        $leapBugTest = \DateTime::createFromFormat('Y-m-d', '2016-03-21');
+        return $leapBugTest->format('z') != '80';
     }
 
     /**


### PR DESCRIPTION
The current leap year bug test returns true on our environment (PHP 5.5, Ubuntu Trusty).
However this results in a duplicate date when generatting dates from a daily pattern.

It seems like the bug only occurs when you create a DateTime object from dayofyear number.
But it does not occur when you extract dayofyear from a DateTime object.

See the patch below for a solution.

This is the same problem as issue #38 