### PR TITLE
Updates to Rule::getString to match RFC 5545

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -87,6 +87,9 @@ use Recurr\Weekday;
  */
 class Rule
 {
+    const TZ_FIXED = 'fixed';
+    const TZ_FLOAT = 'floating';
+
     public static $freqs = array(
         'YEARLY'   => 0,
         'MONTHLY'  => 1,
@@ -375,37 +378,53 @@ class Rule
      *
      * @return string
      */
-    public function getString()
+    public function getString($timezoneType=self::TZ_FLOAT)
     {
+        $format = 'Ymd\THis';
+
         $parts = array();
 
         // FREQ
         $parts[] = 'FREQ='.$this->getFreqAsText();
 
         // UNTIL or COUNT
-        // Until should always be expressed in UTC, just to be safe
-        $until = clone $this->getUntil();
-        $until->setTimezone(new \DateTimeZone('UTC'));
-
+        $until = $this->getUntil();
         $count = $this->getCount();
         if (!empty($until)) {
-            $parts[] = 'UNTIL='.$until->format('Ymd\THis\Z');
+            if ($timezoneType === self::TZ_FIXED) {
+                $u = clone $until;
+                $u->setTimezone(new \DateTimeZone('UTC'));
+                $parts[] = 'UNTIL='.$u->format($format.'\Z');
+            } else {
+                $parts[] = 'UNTIL='.$until->format($format);
+            }
         } elseif (!empty($count)) {
             $parts[] = 'COUNT='.$count;
         }
 
         // DTSTART
         if ($this->isStartDateFromDtstart) {
-            $d = $this->getStartDate();
-            $tzid = $d->getTimezone()->getName();
-            $date = $d->format('Ymd\THis');
-
-            $parts[] = "DTSTART;TZID=$tzid:$date";
+            if ($timezoneType === TZ_FIXED) {
+                $d = $this->getStartDate();
+                $tzid = $d->getTimezone()->getName();
+                $date = $d->format($format);
+                $parts[] = "DTSTART;TZID=$tzid:$date";
+            } else {
+                $parts[] = 'DTSTART='.$this->getStartDate()->format($format);
+            }
         }
 
         // DTEND
         if ($this->endDate instanceof \DateTime) {
-            $parts[] = 'DTEND='.$this->getEndDate()->format('Ymd\THis');
+            if ($timezoneType === TZ_FIXED) {
+                $d = $this->getEndDate();
+                $tzid = $d->getTimezone()->getName();
+                $date = $d->format($format);
+
+                $parts[] = "DTEND;TZID=$tzid:$date";
+            } else {
+                $parts[] = 'DTEND='.$this->getEndDate()->format($format);
+            }
         }
 
         // INTERVAL

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -404,7 +404,7 @@ class Rule
 
         // DTSTART
         if ($this->isStartDateFromDtstart) {
-            if ($timezoneType === TZ_FIXED) {
+            if ($timezoneType === self::TZ_FIXED) {
                 $d = $this->getStartDate();
                 $tzid = $d->getTimezone()->getName();
                 $date = $d->format($format);
@@ -416,7 +416,7 @@ class Rule
 
         // DTEND
         if ($this->endDate instanceof \DateTime) {
-            if ($timezoneType === TZ_FIXED) {
+            if ($timezoneType === self::TZ_FIXED) {
                 $d = $this->getEndDate();
                 $tzid = $d->getTimezone()->getName();
                 $date = $d->format($format);

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -383,17 +383,24 @@ class Rule
         $parts[] = 'FREQ='.$this->getFreqAsText();
 
         // UNTIL or COUNT
-        $until = $this->getUntil();
+        // Until should always be expressed in UTC, just to be safe
+        $until = clone $this->getUntil();
+        $until->setTimezone(new \DateTimeZone('UTC'));
+
         $count = $this->getCount();
         if (!empty($until)) {
-            $parts[] = 'UNTIL='.$until->format('Ymd\THis');
+            $parts[] = 'UNTIL='.$until->format('Ymd\THis\Z');
         } elseif (!empty($count)) {
             $parts[] = 'COUNT='.$count;
         }
 
         // DTSTART
         if ($this->isStartDateFromDtstart) {
-            $parts[] = 'DTSTART='.$this->getStartDate()->format('Ymd\THis');
+            $d = $this->getStartDate();
+            $tzid = $d->getTimezone()->getName();
+            $date = $d->format('Ymd\THis');
+
+            $parts[] = "DTSTART;TZID=$tzid:$date";
         }
 
         // DTEND


### PR DESCRIPTION
Rule::getString should now match what is expressed in the iCal spec RFC 5545
https://tools.ietf.org/html/rfc5545#section-3.3.5
https://tools.ietf.org/html/rfc5545#section-3.3.10

This allows developers to request either fixed or floating time for their RRULE string.  Some (many?) web service apis require fixed, explicit timezone information in the format.

Fixes #37 

