### PR TITLE
Fix the date format for the Dutch language

### DIFF
--- a/translations/nl.php
+++ b/translations/nl.php
@@ -32,10 +32,10 @@ return array(
     '(~ approximate)' => '(~ ongeveer)',
     'until %date%' => 'tot en met %date%', // e.g. every year until July 4, 2014
     'day_date' => function ($str, $params) use ($days, $months) { // outputs a day date, e.g. July 4, 2014
-        return $months[date('n', $params['date']) - 1] . ' '. date('j, Y', $params['date']);
+        return date('j', $params['date']).' '.$months[date('n', $params['date']) - 1] . ' '. date('Y', $params['date']);
     },
     'day_month' => function ($str, $params) use ($days, $months) { // outputs a day month, e.g. July 4
-        return $months[$params['month'] - 1].' '.$params['day'];
+        return $params['day'].' '.$months[$params['month'] - 1];
     },
     'day_names' => $days,
     'month_names' => $months,


### PR DESCRIPTION
In the Netherlands, we use the date format `d-m-Y` instead of `Y-m-d` (for example: 5 oktober 2016).
