### PR TITLE
Add Recurrence[] typehint for ArrayTransformer

### DIFF
--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -80,7 +80,7 @@ class ArrayTransformer
      * @param bool                     $countConstraintFailures Whether recurrences that fail the constraint's test
      *                                                          should count towards a rule's COUNT limit.
      *
-     * @return RecurrenceCollection
+     * @return RecurrenceCollection|Recurrence[]
      * @throws MissingData
      */
     public function transform(Rule $rule, ConstraintInterface $constraint = null, $countConstraintFailures = true)


### PR DESCRIPTION
While it might not be an actual array, it does behave that way when looping in a foreach(). This will provide completion (at least in PHPstorm) for the looped objects.