### PR TITLE
Added index property to Recurrence

### DIFF
--- a/src/Recurr/Recurrence.php
+++ b/src/Recurr/Recurrence.php
@@ -24,6 +24,9 @@ class Recurrence
     /** @var \DateTime */
     protected $end;
 
+    /** @var int */
+    protected $index;
+
     public function __construct(\DateTime $start = null, \DateTime $end = null, $index = 0)
     {
         if ($start instanceof \DateTime) {

--- a/src/Recurr/Recurrence.php
+++ b/src/Recurr/Recurrence.php
@@ -24,7 +24,7 @@ class Recurrence
     /** @var \DateTime */
     protected $end;
 
-    public function __construct(\DateTime $start = null, \DateTime $end = null, int $index = 0)
+    public function __construct(\DateTime $start = null, \DateTime $end = null, $index = 0)
     {
         if ($start instanceof \DateTime) {
             $this->setStart($start);
@@ -80,7 +80,7 @@ class Recurrence
     /**
      * @param int $index
      */
-    public function setIndex(int $index)
+    public function setIndex($index)
     {
         $this->index = $index;
     }

--- a/src/Recurr/Recurrence.php
+++ b/src/Recurr/Recurrence.php
@@ -24,7 +24,7 @@ class Recurrence
     /** @var \DateTime */
     protected $end;
 
-    public function __construct(\DateTime $start = null, \DateTime $end = null)
+    public function __construct(\DateTime $start = null, \DateTime $end = null, int $index = 0)
     {
         if ($start instanceof \DateTime) {
             $this->setStart($start);
@@ -33,6 +33,8 @@ class Recurrence
         if ($end instanceof \DateTime) {
             $this->setEnd($end);
         }
+
+        $this->index = $index;
     }
 
     /**
@@ -65,5 +67,21 @@ class Recurrence
     public function setEnd($end)
     {
         $this->end = $end;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @param int $index
+     */
+    public function setIndex(int $index)
+    {
+        $this->index = $index;
     }
 }

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -540,7 +540,7 @@ class ArrayTransformer
                             }
                         }
                     } else {
-                        $dates[] = $dtTmp;
+                        $dates[$total] = $dtTmp;
                     }
 
                     if (null !== $count) {
@@ -588,7 +588,7 @@ class ArrayTransformer
                                 }
                             }
                         } else {
-                            $dates[] = clone $dtTmp;
+                            $dates[$total] = clone $dtTmp;
                         }
 
                         if (null !== $count) {
@@ -685,11 +685,11 @@ class ArrayTransformer
 
         /** @var Recurrence[] $recurrences */
         $recurrences = array();
-        foreach ($dates as $start) {
+        foreach ($dates as $key => $start) {
             /** @var \DateTime $end */
             $end = clone $start;
 
-            $recurrences[] = new Recurrence($start, $end->add($durationInterval));
+            $recurrences[] = new Recurrence($start, $end->add($durationInterval), $key);
         }
 
         $recurrences = $this->handleInclusions($rule->getRDates(), $recurrences);

--- a/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
@@ -101,4 +101,18 @@ class ArrayTransformerTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2003-01-12 08:30:00'), $computed[28]->getStart());
         $this->assertEquals(new \DateTime('2003-01-12 09:30:00'), $computed[29]->getStart());
     }
+
+    public function testIndex()
+    {
+        $rule = new Rule(
+            'FREQ=YEARLY;COUNT=10',
+            new \DateTime('2000-01-01 09:00:00')
+        );
+
+        $computed = $this->transformer->transform($rule);
+
+        $this->assertCount(10, $computed);
+        $this->assertEquals(1, $computed[0]->getIndex());
+        $this->assertEquals(10, $computed[9]->getIndex());
+    }
 }


### PR DESCRIPTION
Added an `index` property to the `Recurrence` class, which specifies the index of the occurrence.

Get/set the index using the getter/setter on a Recurrence object: `getIndex()` and `setIndex($int)`.

Note that passing `false` as the third parameter of `ArrayTransformer`'s `transform` method will make the index start at the start of the given constraint.

I noticed this is mentioned in [issue 108](https://github.com/simshaun/recurr/issues/108).