### PR TITLE
Fix for for bysetpos transformation

### DIFF
--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -472,7 +472,7 @@ class ArrayTransformer
                 }
             }
 
-            if (!empty($bySetPos)) {
+            if (!empty($bySetPos) && !empty($daySet)) {
                 $datesAdj  = array();
                 $tmpDaySet = array_combine($daySet, $daySet);
 

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -16,6 +16,7 @@ namespace Recurr\Transformer;
 
 use Recurr\DateExclusion;
 use Recurr\DateInclusion;
+use Recurr\Exception\InvalidWeekday;
 use Recurr\Frequency;
 use Recurr\Recurrence;
 use Recurr\RecurrenceCollection;
@@ -80,6 +81,7 @@ class ArrayTransformer
      *                                                          should count towards a rule's COUNT limit.
      *
      * @return RecurrenceCollection|Recurrence[]
+     * @throws InvalidWeekday
      */
     public function transform(Rule $rule, ConstraintInterface $constraint = null, $countConstraintFailures = true)
     {

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -205,7 +205,6 @@ class ArrayTransformer
 
         $year   = $dt->format('Y');
         $month  = $dt->format('n');
-        $day    = $dt->format('j');
         $hour   = $dt->format('G');
         $minute = $dt->format('i');
         $second = $dt->format('s');
@@ -617,7 +616,6 @@ class ArrayTransformer
                 case Frequency::YEARLY:
                     $year += $rule->getInterval();
                     $month = $dt->format('n');
-                    $day   = $dt->format('j');
                     $dt->setDate($year, $month, 1);
                     break;
                 case Frequency::MONTHLY:
@@ -644,26 +642,22 @@ class ArrayTransformer
                     $dt->modify("+$delta day");
                     $year  = $dt->format('Y');
                     $month = $dt->format('n');
-                    $day   = $dt->format('j');
                     break;
                 case Frequency::DAILY:
                     $dt->modify('+'.$rule->getInterval().' day');
                     $year  = $dt->format('Y');
                     $month = $dt->format('n');
-                    $day   = $dt->format('j');
                     break;
                 case Frequency::HOURLY:
                     $dt->modify('+'.$rule->getInterval().' hours');
                     $year  = $dt->format('Y');
                     $month = $dt->format('n');
-                    $day   = $dt->format('j');
                     $hour  = $dt->format('G');
                     break;
                 case Frequency::MINUTELY:
                     $dt->modify('+'.$rule->getInterval().' minutes');
                     $year   = $dt->format('Y');
                     $month  = $dt->format('n');
-                    $day    = $dt->format('j');
                     $hour   = $dt->format('G');
                     $minute = $dt->format('i');
                     break;
@@ -671,7 +665,6 @@ class ArrayTransformer
                     $dt->modify('+'.$rule->getInterval().' seconds');
                     $year   = $dt->format('Y');
                     $month  = $dt->format('n');
-                    $day    = $dt->format('j');
                     $hour   = $dt->format('G');
                     $minute = $dt->format('i');
                     $second = $dt->format('s');

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -496,6 +496,9 @@ class ArrayTransformer
 
                     if ($dayPos < 0) {
                         $nextInSet = array_slice($tmp, $dayPos, 1);
+                        if (count($nextInSet) === 0) {
+                            continue;
+                        }
                         $nextInSet = $nextInSet[0];
                     } else {
                         $nextInSet = $tmp[$dayPos];

--- a/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
@@ -98,4 +98,46 @@ class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-02-09'), $computed[8]->getStart());
         $this->assertEquals(new \DateTime('2015-04-13'), $computed[9]->getStart());
     }
+
+    public function testIndexErrorOnEmptySet()
+    {
+        $rule = new Rule(
+            'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
+            new \DateTime('2018-07-01')
+        );
+
+        $computed = $this->transformer->transform($rule);
+
+        $this->assertCount(18, $computed);
+    }
+
+    public function testBySetPositionHandlesMultipleNegatives()
+    {
+        $rule = new Rule(
+            'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
+            new \DateTime('2018-11-01')
+        );
+
+        $computed = $this->transformer->transform($rule);
+
+        $this->assertCount(18, $computed);
+        $this->assertEquals(new \DateTime('2017-11-02'), $computed[0]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-03'), $computed[1]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-09'), $computed[4]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-10'), $computed[2]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-16'), $computed[3]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-17'), $computed[5]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-23'), $computed[6]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-24'), $computed[7]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-30'), $computed[8]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-01'), $computed[9]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-07'), $computed[10]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-08'), $computed[11]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-14'), $computed[12]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-15'), $computed[13]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-21'), $computed[14]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-22'), $computed[15]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-28'), $computed[16]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-29'), $computed[17]->getStart());
+    }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
@@ -99,11 +99,11 @@ class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-04-13'), $computed[9]->getStart());
     }
 
-    public function testIndexErrorOnEmptySet()
+    public function testNoIndexErrorOnEmptySet()
     {
         $rule = new Rule(
             'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
-            new \DateTime('2018-07-01')
+            new \DateTime('2017-07-01')
         );
 
         $computed = $this->transformer->transform($rule);
@@ -115,29 +115,29 @@ class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
     {
         $rule = new Rule(
             'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
-            new \DateTime('2018-11-01')
+            new \DateTime('2017-11-01')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(18, $computed);
-        $this->assertEquals(new \DateTime('2017-11-02'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-03'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-09'), $computed[4]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-02'), $computed[1]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-03'), $computed[0]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-09'), $computed[3]->getStart());
         $this->assertEquals(new \DateTime('2017-11-10'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-16'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-17'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-23'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-24'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-30'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-01'), $computed[9]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-07'), $computed[10]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-08'), $computed[11]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-14'), $computed[12]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-15'), $computed[13]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-21'), $computed[14]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-22'), $computed[15]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-28'), $computed[16]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-29'), $computed[17]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-16'), $computed[5]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-17'), $computed[4]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-23'), $computed[7]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-24'), $computed[6]->getStart());
+        $this->assertEquals(new \DateTime('2017-11-30'), $computed[9]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-01'), $computed[8]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-07'), $computed[11]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-08'), $computed[10]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-14'), $computed[13]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-15'), $computed[12]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-21'), $computed[15]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-22'), $computed[14]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-28'), $computed[17]->getStart());
+        $this->assertEquals(new \DateTime('2017-12-29'), $computed[16]->getStart());
     }
 }


### PR DESCRIPTION
Here are two failing tests showing some bysetpos issues, along with a fix. Did not properly handle empty arrays.