### PR TITLE
throw an exception on empty BYDAY, as per RFC

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -901,6 +901,9 @@ class Rule
         if ($this->getFreq() > static::$freqs['MONTHLY'] && preg_match('/\d/', implode(',', $byDay))) {
             throw new InvalidRRule('BYDAY only supports MONTHLY and YEARLY frequencies');
         }
+        if (count($byDay) === 0 || $byDay === ['']) {
+            throw new InvalidRRule('BYDAY must be set to at least one day');
+        }
 
         $this->byDay = $byDay;
 

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -305,6 +305,22 @@ class RuleTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Recurr\Exception\InvalidRRule
+     */
+    public function testEmptyByDayThrowsException()
+    {
+        $this->rule->setByDay([]);
+    }
+
+    /**
+     * @expectedException \Recurr\Exception\InvalidRRule
+     */
+    public function testEmptyByDayFromStringThrowsException()
+    {
+        $this->rule->loadFromString('FREQ=WEEKLY;BYDAY=;INTERVAL=1;UNTIL=20160725');
+    }
+
+    /**
      * @expectedException \Recurr\Exception\InvalidArgument
      */
     public function testBadWeekStart()


### PR DESCRIPTION
Checks for empty raw value or the result of an `explode` on "BYDAY=" alone via string inputs and throws an InvalidRRule exception

Fixes https://github.com/simshaun/recurr/issues/98