### PR TITLE
CakePHP 3: Replacing PSR-0 namespaces with PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
 		"phpunit/phpunit": "~4.5"
 	},
 	"autoload": {
-		"psr-0": {
-			"Recurr": "src/"
+		"psr-4": {
+			"Recurr\\": "src/Recurr/",
+			"Recurr\\Test\\": "tests/"
 		}
 	},
 	"extra": {


### PR DESCRIPTION
Good day @simshaun, 
 
Your Recurr package is great, and does exactly what we currently work on. I noticed some issues integrating it with CakePHP 3.x. It appears that they aren't favoring PSR-0 packages, so we introduced this small tweak on bringing Recurr package to PSR-4 namespaces.