### PR TITLE
Fixed issue in transformer where $start is string

### DIFF
--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -89,7 +89,7 @@ class ArrayTransformer
         $end   = $rule->getEndDate();
         $until = $rule->getUntil();
 
-        if (null === $start) {
+        if (null === $start || !$start instanceof \DateTime) {
             $start = new \DateTime(
                 'now', $until instanceof \DateTimeInterface ? $until->getTimezone() : null
             );


### PR DESCRIPTION
Hey, had an issue in my php7.0.22 project where it did not recognize the $start->diff command

Turns out the check on line 102 in ArrayTransformer.php checks if $start is null, but does not initialize it if it's string.

Added a instanceof \DateTime and that worked. 