### PR TITLE
Support custom implementations of Recurrence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "codesmithtech/recurr",
+	"name": "simshaun/recurr",
 	"description": "PHP library for working with recurrence rules",
 	"keywords": ["rrule", "recurrence", "recurring", "events", "dates"],
 	"homepage": "https://github.com/simshaun/recurr",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "simshaun/recurr",
+	"name": "codesmithtech/recurr",
 	"description": "PHP library for working with recurrence rules",
 	"keywords": ["rrule", "recurrence", "recurring", "events", "dates"],
 	"homepage": "https://github.com/simshaun/recurr",

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -668,13 +668,15 @@ class ArrayTransformer
             }
         }
 
+        $recurrenceClassName = $this->config->getRecurrenceClassName();
+
         /** @var Recurrence[] $recurrences */
         $recurrences = array();
         foreach ($dates as $key => $start) {
             /** @var \DateTimeInterface $end */
             $end = clone $start;
 
-            $recurrences[] = new Recurrence($start, $end->add($durationInterval), $key);
+            $recurrences[] = new $recurrenceClassName($start, $end->add($durationInterval), $key);
         }
 
         $recurrences = $this->handleInclusions($rule->getRDates(), $recurrences);
@@ -726,8 +728,10 @@ class ArrayTransformer
      */
     protected function handleInclusions(array $inclusions, array $recurrences)
     {
+        $recurrenceClassName = $this->config->getRecurrenceClassName();
+
         foreach ($inclusions as $inclusion) {
-            $recurrence = new Recurrence(clone $inclusion->date, clone $inclusion->date);
+            $recurrence = new $recurrenceClassName(clone $inclusion->date, clone $inclusion->date);
             $recurrences[] = $recurrence;
         }
 

--- a/src/Recurr/Transformer/ArrayTransformerConfig.php
+++ b/src/Recurr/Transformer/ArrayTransformerConfig.php
@@ -16,6 +16,9 @@ class ArrayTransformerConfig
 
     protected $lastDayOfMonthFix = false;
 
+    /** @var string */
+    protected $recurrenceClassName = '\Recurr\Recurrence';
+
     /**
      * Set the virtual limit imposed upon infinitely recurring events.
      *
@@ -61,5 +64,24 @@ class ArrayTransformerConfig
     public function isLastDayOfMonthFixEnabled()
     {
         return $this->lastDayOfMonthFix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecurrenceClassName()
+    {
+        return $this->recurrenceClassName;
+    }
+
+    /**
+     * Set the class to use when generating a collection of recurrences
+     * Defaults to the Recurrence class in this package
+     *
+     * @param string $recurrenceClassName
+     */
+    public function setRecurrenceClassName($recurrenceClassName)
+    {
+        $this->recurrenceClassName = $recurrenceClassName;
     }
 }


### PR DESCRIPTION
The ArrayTransformer class currently instantiates Recurrence objects directly within its transform() method.

I propose adding a new getter/setter to the ArrayTransformerConfig that allows the user to specofy a class to use when instantiating new Recurrence objects. By default, the Recurrence class provided in the package will be used.

#131 