### PR TITLE
Add support for Hourly freq. on TextTransformer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
 before_script:
     - composer self-update
     - composer update nothing
-    - composer --prefer-source --dev install
+    - composer --prefer-source install
 script: ./vendor/bin/phpunit --coverage-text

--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -217,6 +217,28 @@ class TextTransformer
             $this->addByDay($rule);
         }
     }
+    
+    protected function addHourly(Rule $rule)
+    {
+        $interval = $rule->getInterval();
+        $byMonth = $rule->getByMonth();
+
+        $this->addFragment($this->translator->trans($this->isPlural($interval) ? 'every %count% hours' : 'every hour', array('count' => $interval)));
+
+        if (!empty($byMonth)) {
+            $this->addFragment($this->translator->trans('in_month'));
+            $this->addByMonth($rule);
+        }
+
+        $byMonthDay = $rule->getByMonthDay();
+        $byDay      = $rule->getByDay();
+        if (!empty($byMonthDay)) {
+            $this->addByMonthDay($rule);
+            $this->addFragment($this->translator->trans('of_the_month'));
+        } else if (!empty($byDay)) {
+            $this->addByDay($rule);
+        }
+    }
 
     protected function addByMonth(Rule $rule)
     {

--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -32,6 +32,8 @@ class TextTransformer
                 $this->addDaily($rule);
                 break;
             case 4:
+                $this->addHourly($rule);
+                break;
             case 5:
             case 6:
                 return $this->translator->trans('Unable to fully convert this rrule to text.');
@@ -59,7 +61,7 @@ class TextTransformer
 
     protected function isFullyConvertible(Rule $rule)
     {
-        if ($rule->getFreq() >= 4) {
+        if ($rule->getFreq() >= 5) {
             return false;
         }
 

--- a/tests/Recurr/Test/Transformer/TextTransformerTest.php
+++ b/tests/Recurr/Test/Transformer/TextTransformerTest.php
@@ -261,6 +261,40 @@ class TextTransformerTest extends \PHPUnit_Framework_TestCase
                 'FREQ=YEARLY;BYMONTH=3;UNTIL=20121231T235959Z',
                 'yearly on March 16 until December 31, 2012'
             ),
+
+            // Hourly
+            array(
+                'FREQ=HOURLY',
+                'hourly',
+            ),
+            // HourlyPlural
+            array(
+                'FREQ=HOURLY;INTERVAL=10',
+                'every 10 hours',
+            ),
+            // HourlyByMonth
+            array(
+                'FREQ=HOURLY;BYMONTH=1,8,5',
+                'hourly in January, May and August',
+            ),
+            array(
+                'FREQ=HOURLY;INTERVAL=2;BYMONTH=1,8,5',
+                'every 2 hours in January, May and August',
+            ),
+            // HourlyByMonthDay
+            array(
+                'FREQ=HOURLY;BYMONTHDAY=5,1,21',
+                'hourly on the 1st, 5th and 21st of the month'
+            ),
+            array(
+                'FREQ=HOURLY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
+                'hourly on Tuesday or Friday the 1st, 5th or 21st of the month',
+            ),
+            // HourlyByDay
+            array(
+                'FREQ=HOURLY;BYDAY=TU,WE,FR',
+                'hourly on Tuesday, Wednesday and Friday',
+            ),
         );
 
         $tests = array();

--- a/tests/Recurr/Test/Transformer/Translations/de.yml
+++ b/tests/Recurr/Test/Transformer/Translations/de.yml
@@ -56,3 +56,12 @@
 "every 2 years on March 16": "alle 2 Jahre am 16. März"
 "yearly on March 16 for 5 times": "jährlich am 16. März 5 Mal"
 "yearly on March 16 until December 31, 2012": "jährlich am 16. März bis 31. Dezember, 2012"
+
+# hourly tests
+"hourly": "stündlich"
+"every 10 hours": "alle 10 Stunden"
+"hourly in January, May and August": "stündlich im Januar, Mai und August"
+"every 2 hours in January, May and August": "alle 2 Stunden im Januar, Mai und August"
+"hourly on the 1st, 5th and 21st of the month": "stündlich am 1., 5. und 21. des Monats"
+"hourly on Tuesday or Friday the 1st, 5th or 21st of the month": "stündlich am Dienstag oder Freitag dem 1., 5. oder 21. des Monats"
+"hourly on Tuesday, Wednesday and Friday": "stündlich am Dienstag, Mittwoch und Freitag"

--- a/tests/Recurr/Test/Transformer/Translations/en.yml
+++ b/tests/Recurr/Test/Transformer/Translations/en.yml
@@ -56,3 +56,12 @@
 "every 2 years on March 16": "every 2 years on March 16"
 "yearly on March 16 for 5 times": "yearly on March 16 for 5 times"
 "yearly on March 16 until December 31, 2012": "yearly on March 16 until December 31, 2012"
+
+# hourly tests
+"hourly": "hourly"
+"every 10 hours": "every 10 hours"
+"hourly in January, May and August": "hourly in January, May and August"
+"every 2 hours in January, May and August": "every 2 hours in January, May and August"
+"hourly on the 1st, 5th and 21st of the month": "hourly on the 1st, 5th and 21st of the month"
+"hourly on Tuesday or Friday the 1st, 5th or 21st of the month": "hourly on Tuesday or Friday the 1st, 5th or 21st of the month"
+"hourly on Tuesday, Wednesday and Friday": "hourly on Tuesday, Wednesday and Friday"

--- a/tests/Recurr/Test/Transformer/Translations/fr.yml
+++ b/tests/Recurr/Test/Transformer/Translations/fr.yml
@@ -56,3 +56,12 @@
 "every 2 years on March 16": "tous les 2 ans le 16 mars"
 "yearly on March 16 for 5 times": "chaque année le 16 mars 5 fois"
 "yearly on March 16 until December 31, 2012": "chaque année le 16 mars jusqu'au 31 décembre, 2012"
+
+# hourly tests
+"hourly": "chaque heure"
+"every 10 hours": "toutes les 10 heures"
+"hourly in January, May and August": "chaque heure en janvier, mai et août"
+"every 2 hours in January, May and August": "toutes les 2 heures en janvier, mai et août"
+"hourly on the 1st, 5th and 21st of the month": "chaque heure le 1, 5 et 21 du mois"
+"hourly on Tuesday or Friday the 1st, 5th or 21st of the month": "chaque heure le mardi ou vendredi le 1, 5 ou 21 du mois"
+"hourly on Tuesday, Wednesday and Friday": "chaque heure le mardi, mercredi et vendredi"

--- a/tests/Recurr/Test/Transformer/Translations/it.yml
+++ b/tests/Recurr/Test/Transformer/Translations/it.yml
@@ -56,3 +56,12 @@
 "every 2 years on March 16": "ogni 2 anni il 16 marzo"
 "yearly on March 16 for 5 times": "ogni anno il 16 marzo per 5 volte"
 "yearly on March 16 until December 31, 2012": "ogni anno il 16 marzo fino al 31 dicembre, 2012"
+
+# hourly tests
+"hourly": "ogni ora"
+"every 10 hours": "ogni 10 ore"
+"hourly in January, May and August": "ogni ora in gennaio, maggio e agosto"
+"every 2 hours in January, May and August": "ogni 2 ore in gennaio, maggio e agosto"
+"hourly on the 1st, 5th and 21st of the month": "ogni ora il 1, 5 e 21 del mese"
+"hourly on Tuesday or Friday the 1st, 5th or 21st of the month": "ogni ora il martedì o venerdì il 1, 5 o 21 del mese"
+"hourly on Tuesday, Wednesday and Friday": "ogni ora il martedì, mercoledì e venerdì"

--- a/translations/de.php
+++ b/translations/de.php
@@ -57,11 +57,15 @@ return array(
     'every week' => 'wöchentlich',
     'every %count% days' => 'alle %count% Tage',
     'every day' => 'täglich',
+    'every %count% hours' => 'alle %count% Stunden',
+    'every hour' => 'stündlich',
     'last' => 'letzte', // e.g. 2nd last Friday
     'days' => 'Tage',
     'day' => 'Tag',
     'weeks' => 'Wochen',
     'week' => 'Woche',
+    'hours' => 'Stunden',
+    'hour' => 'stündlich',
     // formats a number with a prefix e.g. every year on the 1st and 200th day
     // negative numbers should be handled as in '5th to the last' or 'last'
     //

--- a/translations/en.php
+++ b/translations/en.php
@@ -57,6 +57,8 @@ return array(
     'every week' => 'weekly',
     'every %count% days' => 'every %count% days',
     'every day' => 'daily',
+    'every %count% hours' => 'every %count% hours',
+    'every hour' => 'hourly',
     'last' => 'last', // e.g. 2nd last Friday
     'days' => 'days',
     'day' => 'day',

--- a/translations/en.php
+++ b/translations/en.php
@@ -64,6 +64,8 @@ return array(
     'day' => 'day',
     'weeks' => 'weeks',
     'week' => 'week',
+    'hours' => 'hours',
+    'hour' => 'hour',
     // formats a number with a prefix e.g. every year on the 1st and 200th day
     // negative numbers should be handled as in '5th to the last' or 'last'
     //

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -64,6 +64,8 @@ return array(
     'day' => 'jour',
     'weeks' => 'semaines',
     'week' => 'semaine',
+    'hours' => 'heures',
+    'hour' => 'heure',
     // formats a number with a prefix e.g. every year on the 1st and 200th day
     // negative numbers should be handled as in '5th to the last' or 'last'
     //

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -57,6 +57,8 @@ return array(
     'every week' => 'chaque semaine',
     'every %count% days' => 'tous les %count% jours',
     'every day' => 'chaque jour',
+    'every %count% hours' => 'toutes les %count% heures',
+    'every hour' => 'chaque heure',
     'last' => 'dernier', // e.g. 2nd last Friday
     'days' => 'jours',
     'day' => 'jour',

--- a/translations/it.php
+++ b/translations/it.php
@@ -57,11 +57,15 @@ return array(
     'every week' => 'ogni settimana',
     'every %count% days' => 'ogni %count% giorni',
     'every day' => 'ogni giorno',
+    'every %count% hours' => 'ogni %count% ore',
+    'every hour' => 'ogni ora',
     'last' => 'scorso', // e.g. 2nd last Friday
     'days' => 'giorni',
     'day' => 'giorno',
     'weeks' => 'settimane',
     'week' => 'settimana',
+    'hours' => 'ore',
+    'hour' => 'ora',
     // formats a number with a prefix e.g. every year on the 1st and 200th day
     // negative numbers should be handled as in '5th to the last' or 'last'
     //


### PR DESCRIPTION
### Done
- add support for Hourly freq. on TextTransformer
- [travis] composer option "dev" is deprecated. Dev packages are installed by default now.
- [travis] add PHP 7.2

### Todo
- need more tests ?
- [ ] DE & IT translations need to be verified, someone can help ?