### PR TITLE
Fix issue where first of january is skipped

### DIFF
--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -489,7 +489,7 @@ class ArrayTransformer
                         $nextInSet = isset($tmp[$dayPos]) ? $tmp[$dayPos] : null;
                     }
 
-                    if ($nextInSet) {
+                    if (! is_null($nextInSet)) {
                         /** @var Time $time */
                         $time = $timeSet[$timePos];
 

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -489,7 +489,7 @@ class ArrayTransformer
                         $nextInSet = isset($tmp[$dayPos]) ? $tmp[$dayPos] : null;
                     }
 
-                    if (! is_null($nextInSet)) {
+                    if (null !== $nextInSet) {
                         /** @var Time $time */
                         $time = $timeSet[$timePos];
 

--- a/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
@@ -115,4 +115,15 @@ class ArrayTransformerTest extends ArrayTransformerBase
         $this->assertEquals(1, $computed[0]->getIndex());
         $this->assertEquals(10, $computed[9]->getIndex());
     }
+
+    public function testOccurrenceBySetPosOnJanuaryFirst()
+    {
+        $rule = new Rule('FREQ=MONTHLY;COUNT=4;BYSETPOS=1', new \DateTime('2018-11-01'));
+        $computed = $this->transformer->transform($rule);
+        $this->assertCount(4, $computed);
+        $this->assertEquals(new \DateTime('2018-11-01'), $computed[0]->getStart());
+        $this->assertEquals(new \DateTime('2018-12-01'), $computed[1]->getStart());
+        $this->assertEquals(new \DateTime('2019-01-01'), $computed[2]->getStart());
+        $this->assertEquals(new \DateTime('2019-02-01'), $computed[3]->getStart());
+    }
 }


### PR DESCRIPTION
When using a BYSETPOS in a RRule the first of january is skipped because of a loose comparison.

Fixes #141 