### PR TITLE
Fix loadFromString with "DTSTART" and "RRULE" on new lines.

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -264,11 +264,48 @@ class Rule
     {
         $rrule  = strtoupper($rrule);
         $rrule  = trim($rrule, ';');
+        $rrule  = trim($rrule, "\n");
+        $rows   = explode("\n", $rrule);
+
+        $parts = array();
+
+        foreach ($rows as $rruleForRow) {
+            $parts = array_merge($parts, $this->parseString($rruleForRow));
+        }
+
+        return $this->loadFromArray($parts);
+    }
+
+    /**
+     * Parse string for parts
+     *
+     * @param string $rrule
+     *
+     * @return array
+     *
+     * @throws InvalidRRule
+     */
+    public function parseString($rrule)
+    {
+        if (strpos($rrule, 'DTSTART:') === 0) {
+            $pieces = explode(':', $rrule);
+
+            if (count($pieces) !== 2) {
+                throw new InvalidRRule('DSTART is not valid');
+            }
+
+            return array('DTSTART' => $pieces[1]);
+        }
+
+        if (strpos($rrule, 'RRULE:') === 0) {
+            $rrule = str_replace('RRULE:', '', $rrule);
+        }
+
         $pieces = explode(';', $rrule);
         $parts  = array();
 
         if (!count($pieces)) {
-            throw new InvalidRRule('RRULE is empty');
+            throw new InvalidRRule('DSTART is not valid');
         }
 
         // Split each piece of the RRULE in to KEY=>VAL
@@ -281,7 +318,7 @@ class Rule
             $parts[$key] = $val;
         }
 
-        return $this->loadFromArray($parts);
+        return $parts;
     }
 
     /**

--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -305,7 +305,7 @@ class Rule
         $parts  = array();
 
         if (!count($pieces)) {
-            throw new InvalidRRule('DSTART is not valid');
+            throw new InvalidRRule('RRULE is empty');
         }
 
         // Split each piece of the RRULE in to KEY=>VAL

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -118,6 +118,112 @@ class RuleTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testLoadFromStringWithDtStartDirective()
+    {
+        $string = 'DTSTART:20190102';
+        $string .= "\n";
+        $string .= 'RRULE:';
+        $string .= 'FREQ=YEARLY;';
+        $string .= 'COUNT=2;';
+        $string .= 'INTERVAL=2;';
+        $string .= 'BYSECOND=30;';
+        $string .= 'BYMINUTE=10;';
+        $string .= 'BYHOUR=5,15;';
+        $string .= 'BYDAY=SU,WE;';
+        $string .= 'BYMONTHDAY=16,22;';
+        $string .= 'BYYEARDAY=201,203;';
+        $string .= 'BYWEEKNO=29,32;';
+        $string .= 'BYMONTH=7,8;';
+        $string .= 'BYSETPOS=1,3;';
+        $string .= 'WKST=TU;';
+        $string .= 'RDATE=20151210,20151214T020000,20151215T210000Z;';
+        $string .= 'EXDATE=20140607,20140620T010000,20140620T160000Z;';
+
+        $this->rule->loadFromString($string);
+
+        $this->assertEquals(Frequency::YEARLY, $this->rule->getFreq());
+        $this->assertEquals(new \DateTime('2019-01-02'), $this->rule->getStartDate());
+        $this->assertEquals(2, $this->rule->getCount());
+        $this->assertEquals(2, $this->rule->getInterval());
+        $this->assertEquals(array(30), $this->rule->getBySecond());
+        $this->assertEquals(array(10), $this->rule->getByMinute());
+        $this->assertEquals(array(5, 15), $this->rule->getByHour());
+        $this->assertEquals(array('SU', 'WE'), $this->rule->getByDay());
+        $this->assertEquals(array(16, 22), $this->rule->getByMonthDay());
+        $this->assertEquals(array(201, 203), $this->rule->getByYearDay());
+        $this->assertEquals(array(29, 32), $this->rule->getByWeekNumber());
+        $this->assertEquals(array(7, 8), $this->rule->getByMonth());
+        $this->assertEquals(array(1, 3), $this->rule->getBySetPosition());
+        $this->assertEquals('TU', $this->rule->getWeekStart());
+        $this->assertEquals(
+            array(
+                new DateInclusion(new \DateTime(20151210), false),
+                new DateInclusion(new \DateTime('20151214T020000'), true),
+                new DateInclusion(new \DateTime('20151215 21:00:00 UTC'), true, true)
+            ),
+            $this->rule->getRDates()
+        );
+        $this->assertEquals(
+            array(
+                new DateExclusion(new \DateTime(20140607), false),
+                new DateExclusion(new \DateTime('20140620T010000'), true),
+                new DateExclusion(new \DateTime('20140620 16:00:00 UTC'), true, true)
+            ),
+            $this->rule->getExDates()
+        );
+    }
+
+    public function testLoadFromStringWithRruleDirective()
+    {
+        $string = 'RRULE:';
+        $string .= 'FREQ=YEARLY;';
+        $string .= 'COUNT=2;';
+        $string .= 'INTERVAL=2;';
+        $string .= 'BYSECOND=30;';
+        $string .= 'BYMINUTE=10;';
+        $string .= 'BYHOUR=5,15;';
+        $string .= 'BYDAY=SU,WE;';
+        $string .= 'BYMONTHDAY=16,22;';
+        $string .= 'BYYEARDAY=201,203;';
+        $string .= 'BYWEEKNO=29,32;';
+        $string .= 'BYMONTH=7,8;';
+        $string .= 'BYSETPOS=1,3;';
+        $string .= 'WKST=TU;';
+        $string .= 'RDATE=20151210,20151214T020000,20151215T210000Z;';
+        $string .= 'EXDATE=20140607,20140620T010000,20140620T160000Z;';
+
+        $this->rule->loadFromString($string);
+
+        $this->assertEquals(Frequency::YEARLY, $this->rule->getFreq());
+        $this->assertEquals(2, $this->rule->getCount());
+        $this->assertEquals(2, $this->rule->getInterval());
+        $this->assertEquals(array(30), $this->rule->getBySecond());
+        $this->assertEquals(array(10), $this->rule->getByMinute());
+        $this->assertEquals(array(5, 15), $this->rule->getByHour());
+        $this->assertEquals(array('SU', 'WE'), $this->rule->getByDay());
+        $this->assertEquals(array(16, 22), $this->rule->getByMonthDay());
+        $this->assertEquals(array(201, 203), $this->rule->getByYearDay());
+        $this->assertEquals(array(29, 32), $this->rule->getByWeekNumber());
+        $this->assertEquals(array(7, 8), $this->rule->getByMonth());
+        $this->assertEquals(array(1, 3), $this->rule->getBySetPosition());
+        $this->assertEquals('TU', $this->rule->getWeekStart());
+        $this->assertEquals(
+            array(
+                new DateInclusion(new \DateTime(20151210), false),
+                new DateInclusion(new \DateTime('20151214T020000'), true),
+                new DateInclusion(new \DateTime('20151215 21:00:00 UTC'), true, true)
+            ),
+            $this->rule->getRDates()
+        );
+        $this->assertEquals(
+            array(
+                new DateExclusion(new \DateTime(20140607), false),
+                new DateExclusion(new \DateTime('20140620T010000'), true),
+                new DateExclusion(new \DateTime('20140620 16:00:00 UTC'), true, true)
+            ),
+            $this->rule->getExDates()
+        );
+    }
 
     public function testLoadFromArray()
     {


### PR DESCRIPTION
Hi,

Using the syntax from https://jakubroztocil.github.io/rrule/, it was previously impossible to use "DTSTART" and "RRULE" in this format:

```
DTSTART:20190110T135600Z
RRULE:FREQ=WEEKLY;COUNT=30;INTERVAL=1
```