### PR TITLE
Allow start date to be null

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -197,7 +197,7 @@ class Rule
         }
         $this->setTimezone($timezone);
 
-        if (!$startDate instanceof \DateTimeInterface) {
+        if ($startDate !== null && !$startDate instanceof \DateTimeInterface) {
             $startDate = new \DateTime($startDate, new \DateTimeZone($timezone));
         }
 

--- a/tests/Recurr/Test/RuleTest.php
+++ b/tests/Recurr/Test/RuleTest.php
@@ -20,7 +20,7 @@ class RuleTest extends \PHPUnit_Framework_TestCase
     public function testConstructAcceptableStartDate()
     {
         $this->rule = new Rule(null, null);
-        $this->assertInstanceOf(\DateTime::class, $this->rule->getStartDate());
+        $this->assertNull($this->rule->getStartDate());
 
         $this->rule = new Rule(null, '2018-09-19');
         $this->assertInstanceOf(\DateTime::class, $this->rule->getStartDate());


### PR DESCRIPTION
Hi,

In order to have a start date that has no value (null), to consider that an event has always been valid. Just like the end date.