### PR TITLE
Test against php 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
+dist: bionic
 language: php
 php:
     - 5.6
     - 7.0
     - 7.1
     - 7.2
-before_script:
+    - 7.3
+    - 7.4    
+install:
     - composer self-update
     - composer update nothing
     - composer --prefer-source install
 script: ./vendor/bin/phpunit --coverage-text
+cache:
+  directories:
+    - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 language: php
 php:
     - 5.6


### PR DESCRIPTION
Hi,
I am just adding php `7.3` and `7.4` to travis config, but i think it is good time top drop php 5.x support too,