### PR TITLE
RFC compliance and fixes for issue #137

### DIFF
--- a/src/Recurr/Rule.php
+++ b/src/Recurr/Rule.php
@@ -210,7 +210,7 @@ class Rule
 
         if (is_array($rrule)) {
             $this->loadFromArray($rrule);
-        } else if (!empty($rrule)) {
+        } elseif (!empty($rrule)) {
             $this->loadFromString($rrule);
         }
     }
@@ -286,35 +286,64 @@ class Rule
      */
     public function parseString($rrule)
     {
-        if (strpos($rrule, 'DTSTART:') === 0) {
-            $pieces = explode(':', $rrule);
+        //rrule here can be:
+        //1) DTSTART:20200607T120200
+        //2) DTSTART;TZID=UTC:20200607T120200
+        //3) RRULE:FREQ=DAILY;INTERVAL=1
+        //4) FREQ=DAILY;DTSTART;TZID=UTC:20200607T120200;INTERVAL=1
+        //5) FREQ=DAILY;DTSTART:20200607T120200;INTERVAL=1
 
-            if (count($pieces) !== 2) {
-                throw new InvalidRRule('DSTART is not valid');
-            }
+        //SOLUTION: split by ';':
+        //1) [DTSTART:20200607T120200]
+        //2) [DTSTART, TZID=UTC:20200607T120200]
+        //3) [RRULE:FREQ=DAILY, INTERVAL=1]
+        //4) [FREQ=DAILY, DTSTART, TZID=UTC:20200607T120200, INTERVAL=1]
+        //5) [FREQ=DAILY, DTSTART:20200607T120200, INTERVAL=1]
 
-            return array('DTSTART' => $pieces[1]);
-        }
+        $fragments = explode(';', $rrule);
 
-        if (strpos($rrule, 'RRULE:') === 0) {
-            $rrule = str_replace('RRULE:', '', $rrule);
-        }
-
-        $pieces = explode(';', $rrule);
-        $parts  = array();
-
-        if (!count($pieces)) {
+        if (!count($fragments)) {
             throw new InvalidRRule('RRULE is empty');
         }
 
-        // Split each piece of the RRULE in to KEY=>VAL
-        foreach ($pieces as $piece) {
-            if (false === strpos($piece, '=')) {
+        $parts  = array();
+        foreach ($fragments as $fragment) {
+            if (strpos($fragment, 'RRULE:') === 0) {
+                $fragment = str_replace('RRULE:', '', $fragment);
+            }
+
+
+            if (strpos($fragment, 'DTSTART') === 0) {
+                if ($fragment === 'DTSTART') {
+                    $parts['DTSTART'] = '';//to be replaced by next token
+
+                    continue;
+                }
+
+                $p = explode(':', $fragment);
+                if (count($p) !== 2) {
+                    throw new InvalidRRule('DTSTART is not valid');
+                }
+
+                $parts['DTSTART'] = $p[1];
+
                 continue;
             }
 
-            list($key, $val) = explode('=', $piece);
-            $parts[$key] = $val;
+            if (strpos($fragment, '=')) {
+                list($key, $val) = explode('=', $fragment);
+
+                if ($key === 'TZID') {
+                    $p = explode(':', $val);
+
+                    $parts['TZID'] = $p[0];
+                    $parts['DTSTART'] = $p[1];
+
+                    continue;
+                }
+
+                $parts[$key] = $val;
+            }
         }
 
         return $parts;
@@ -341,11 +370,26 @@ class Rule
             $this->setFreq(self::$freqs[$parts['FREQ']]);
         }
 
+        // TZID
+        if (isset($parts['TZID'])) {
+            $this->setTimezone($parts['TZID']);
+        }
+
         // DTSTART
         if (isset($parts['DTSTART'])) {
             $this->isStartDateFromDtstart = true;
-            $date = new \DateTime($parts['DTSTART']);
-            $date = $date->setTimezone(new \DateTimeZone($this->getTimezone()));
+
+            $timezone = new \DateTimeZone($this->getTimezone());
+            $date = null;
+            if (isset($parts['TZID'])) {
+                //DTSTART is datetime in TZID timezone
+                $date = new \DateTime($parts['DTSTART'], $timezone);
+            } else {
+                //DTSTART is UTC, convert to timezone coming from constructor/startDate/default
+                $date = new \DateTime($parts['DTSTART']);
+                $date = $date->setTimezone($timezone);
+            }
+
             $this->setStartDate($date);
         }
 
@@ -474,12 +518,12 @@ class Rule
                 $date = $d->format($format);
                 $parts[] = "DTSTART;TZID=$tzid:$date";
             } else {
-                $parts[] = 'DTSTART='.$this->getStartDate()->format($format);
+                $parts[] = 'DTSTART:'.$this->getStartDate()->format($format);
             }
         }
 
         // DTEND
-        if ($this->endDate instanceof \DateTime) {
+        if ($this->endDate instanceof \DateTimeInterface) {
             if ($timezoneType === self::TZ_FIXED) {
                 $d = $this->getEndDate();
                 $tzid = $d->getTimezone()->getName();


### PR DESCRIPTION
Bug 1: recurr does not parse rrule string correctly if the string has TZID. At the same time when converting Rule to string recurr is able to output TZID. 
Bug 2: When converting Rule to string, recurr outputs 'DTSTART=', which RFC 5545 doesnt allow, and which recurr is not able to correctly parse

1) Test Recurr is able to parse the string created by itself
2) Fix parsing for the test to pass

Bug 3: If endDate is passed as DateTimeImmutable it is not applied to the produced rrule string because the check is `instanceOf DateTime`. Check for `DateTimeInterface`

DTSTART, DTEND and TZID from rrule string take precedence over constructor parameters