### PR TITLE
Correct Day of Week Parsing

### DIFF
--- a/src/Recurr/Weekday.php
+++ b/src/Recurr/Weekday.php
@@ -41,7 +41,7 @@ class Weekday
     /** @var int nth occurrence of the weekday */
     public $num;
 
-    protected $days = array('MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU');
+    protected $days = array('SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA');
 
     /**
      * @param int|string $weekday 0-6 or MO..SU


### PR DESCRIPTION
This class states that Sunday is 0, but then uses 'MO' as the first element of the array. As a result, the `$weekday` is wrong, and is one day off.