### PR TITLE
PSR-4 autoloader autoload-dev needs to be

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"Recurr\\Test\\": "tests/"
+			"Recurr\\Test\\": "tests/Recurr/Test"
 		}
 	},
 	"extra": {


### PR DESCRIPTION
Relates to #172

autoload-dev fix
```
"Recurr\\Test\\": "tests/Recurr/Test"
```

Additionally, depending on your application's composer.json the warning may not appear.
To show the warning try either enabling the optimize-autoloader either in the composer.json

```
    "config": {
        "preferred-install": "dist",
        "sort-packages": true,
        "optimize-autoloader": false
    },
```

or directly on the command line

```
composer require --optimize-autoloader simshaun/recurr
```