### PR TITLE
Update PHP language level & better RFC compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 /composer.lock
 /.phpunit.result.cache
+.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,15 @@
 {
 	"name": "simshaun/recurr",
-	"description": "PHP library for working with recurrence rules",
-	"keywords": ["rrule", "recurrence", "recurring", "events", "dates"],
-	"homepage": "https://github.com/simshaun/recurr",
 	"type": "library",
+	"description": "PHP library for working with recurrence rules",
+	"keywords": [
+		"rrule",
+		"recurrence",
+		"recurring",
+		"events",
+		"dates"
+	],
+	"homepage": "https://github.com/simshaun/recurr",
 	"license": "MIT",
 	"authors": [
 		{
@@ -13,12 +19,18 @@
 		}
 	],
 	"require": {
-		"php": "^7.2||^8.0",
-		"doctrine/collections": "~1.6"
+		"php": "^8.0",
+		"doctrine/collections": "^1.6"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^8.5.16",
-		"symfony/yaml": "^5.3"
+		"phpunit/phpunit": "^8.5 || ^9.0",
+		"squizlabs/php_codesniffer": "^3.6",
+		"symfony/yaml": "^5.3 || ^6.0"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "0.x-dev"
+		}
 	},
 	"autoload": {
 		"psr-4": {
@@ -28,11 +40,6 @@
 	"autoload-dev": {
 		"psr-4": {
 			"Recurr\\Test\\": "tests/Recurr/Test"
-		}
-	},
-	"extra": {
-		"branch-alias": {
-			"dev-master": "0.x-dev"
 		}
 	},
 	"scripts": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset
+        name="PHPCS Coding Standards"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd"
+>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="colors" />
+    <arg name="cache" value=".phpcs-cache"/>
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
+
+    <rule ref="PSR12"/>
+
+    <file>src</file>
+    <file>tests</file>
+
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,24 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="./tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd">
-  <testsuites>
-    <testsuite name="Recurr Test Suite">
-      <directory suffix="Test.php">./tests/Recurr/Test/</directory>
-    </testsuite>
-  </testsuites>
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
 
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src/Recurr/</directory>
-    </whitelist>
-  </filter>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src/Recurr/</directory>
+        </include>
+    </coverage>
+
+    <testsuites>
+        <testsuite name="Recurr Test Suite">
+            <directory>./tests/Recurr/Test/</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>

--- a/src/Recurr/DateExclusion.php
+++ b/src/Recurr/DateExclusion.php
@@ -9,6 +9,8 @@
 
 namespace Recurr;
 
+use DateTimeInterface;
+
 /**
  * Class DateExclusion is a container for a single \DateTimeInterface.
  *
@@ -23,23 +25,21 @@ namespace Recurr;
  */
 class DateExclusion
 {
-    /** @var \DateTimeInterface */
-    public $date;
+    public DateTimeInterface $date;
 
     /** @var bool Day of year */
-    public $hasTime;
+    public bool $hasTime;
 
-    /** @var bool */
-    public $isUtcExplicit;
+    public bool $isUtcExplicit;
 
     /**
      * Constructor
      *
-     * @param \DateTimeInterface $date
+     * @param DateTimeInterface $date
      * @param bool               $hasTime
      * @param bool               $isUtcExplicit
      */
-    public function __construct(\DateTimeInterface $date, $hasTime = true, $isUtcExplicit = false)
+    public function __construct(DateTimeInterface $date, bool $hasTime = true, bool $isUtcExplicit = false)
     {
         $this->date          = $date;
         $this->hasTime       = $hasTime;

--- a/src/Recurr/DateInclusion.php
+++ b/src/Recurr/DateInclusion.php
@@ -9,6 +9,8 @@
 
 namespace Recurr;
 
+use DateTimeInterface;
+
 /**
  * Class DateInclusion is a container for a single \DateTimeInterface.
  *
@@ -23,23 +25,21 @@ namespace Recurr;
  */
 class DateInclusion
 {
-    /** @var \DateTimeInterface */
-    public $date;
+    public DateTimeInterface $date;
 
     /** @var bool Day of year */
-    public $hasTime;
+    public bool $hasTime;
 
-    /** @var bool */
-    public $isUtcExplicit;
+    public bool $isUtcExplicit;
 
     /**
      * Constructor
      *
-     * @param \DateTimeInterface $date
+     * @param DateTimeInterface $date
      * @param bool               $hasTime
      * @param bool               $isUtcExplicit
      */
-    public function __construct(\DateTimeInterface $date, $hasTime = true, $isUtcExplicit = false)
+    public function __construct(DateTimeInterface $date, bool $hasTime = true, bool $isUtcExplicit = false)
     {
         $this->date          = $date;
         $this->hasTime       = $hasTime;

--- a/src/Recurr/DateInfo.php
+++ b/src/Recurr/DateInfo.php
@@ -13,6 +13,8 @@
 
 namespace Recurr;
 
+use DateTimeInterface;
+
 /**
  * Class DateInfo is responsible for holding information based on a particular
  * date that is applicable to a Rule.
@@ -22,52 +24,51 @@ namespace Recurr;
  */
 class DateInfo
 {
-    /** @var \DateTime */
-    public $dt;
+    public DateTimeInterface $dt;
 
     /**
      * @var int Number of days in the month.
      */
-    public $monthLength;
+    public int $monthLength;
 
     /**
      * @var int Number of days in the year (365 normally, 366 on leap years)
      */
-    public $yearLength;
+    public int $yearLength;
 
     /**
      * @var int Number of days in the next year (365 normally, 366 on leap years)
      */
-    public $nextYearLength;
+    public int $nextYearLength;
 
     /**
      * @var array Day of year of last day of each month.
      */
-    public $mRanges;
+    public array $mRanges;
 
     /** @var int Day of week */
-    public $dayOfWeek;
+    public int $dayOfWeek;
 
     /** @var int Day of week of the year's first day */
-    public $dayOfWeekYearDay1;
+    public int $dayOfWeekYearDay1;
 
     /**
      * @var array Month number for each day of the year.
      */
-    public $mMask;
+    public array $mMask;
 
     /**
      * @var array Month-daynumber for each day of the year.
      */
-    public $mDayMask;
+    public array $mDayMask;
 
     /**
      * @var array Month-daynumber for each day of the year (in reverse).
      */
-    public $mDayMaskNeg;
+    public array $mDayMaskNeg;
 
     /**
      * @var array Day of week (0-6) for each day of the year, 0 being Monday
      */
-    public $wDayMask;
+    public array $wDayMask;
 }

--- a/src/Recurr/DaySet.php
+++ b/src/Recurr/DaySet.php
@@ -21,14 +21,13 @@ namespace Recurr;
  */
 class DaySet
 {
-    /** @var array */
-    public $set;
+    public array $set;
 
     /** @var int Day of year */
-    public $start;
+    public int $start;
 
     /** @var int Day of year */
-    public $end;
+    public int $end;
 
     /**
      * Constructor
@@ -37,7 +36,7 @@ class DaySet
      * @param int   $start Day of year of start day
      * @param int   $end   Day of year of end day
      */
-    public function __construct($set, $start, $end)
+    public function __construct(array $set, int $start, int $end)
     {
         $this->set   = $set;
         $this->start = $start;

--- a/src/Recurr/Exception/Exception.php
+++ b/src/Recurr/Exception/Exception.php
@@ -7,11 +7,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Recurr;
+namespace Recurr\Exception;
 
 /**
  * The base Recurr exception class
  */
-class Exception extends \Exception
+interface Exception extends \Throwable
 {
 }

--- a/src/Recurr/Exception/InvalidArgument.php
+++ b/src/Recurr/Exception/InvalidArgument.php
@@ -9,12 +9,10 @@
 
 namespace Recurr\Exception;
 
-use Recurr\Exception;
-
 /**
  * @package Recurr\Exception
  * @author  Shaun Simmons <shaun@envysphere.com>
  */
-class InvalidArgument extends Exception
+class InvalidArgument extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/Recurr/Exception/InvalidRRule.php
+++ b/src/Recurr/Exception/InvalidRRule.php
@@ -9,12 +9,12 @@
 
 namespace Recurr\Exception;
 
-use Recurr\Exception;
+use Recurr\Exception\Exception;
 
 /**
  * @package Recurr\Exception
  * @author  Shaun Simmons <shaun@envysphere.com>
  */
-class InvalidRRule extends Exception
+class InvalidRRule extends \UnexpectedValueException implements Exception
 {
 }

--- a/src/Recurr/Exception/InvalidWeekday.php
+++ b/src/Recurr/Exception/InvalidWeekday.php
@@ -9,12 +9,12 @@
 
 namespace Recurr\Exception;
 
-use Recurr\Exception;
+use Recurr\Exception\Exception;
 
 /**
  * @package Recurr\Exception
  * @author  Shaun Simmons <shaun@envysphere.com>
  */
-class InvalidWeekday extends Exception
+class InvalidWeekday extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/Recurr/Frequency.php
+++ b/src/Recurr/Frequency.php
@@ -14,7 +14,8 @@
 
 namespace Recurr;
 
-class Frequency {
+class Frequency
+{
     const YEARLY   = 0;
     const MONTHLY  = 1;
     const WEEKLY   = 2;

--- a/src/Recurr/Recurrence.php
+++ b/src/Recurr/Recurrence.php
@@ -9,6 +9,8 @@
 
 namespace Recurr;
 
+use DateTimeInterface;
+
 /**
  * Class Recurrence is responsible for storing the start and end \DateTime of
  * a specific recurrence in a RRULE.
@@ -18,72 +20,51 @@ namespace Recurr;
  */
 class Recurrence
 {
-    /** @var \DateTimeInterface */
-    protected $start;
+    protected ?DateTimeInterface $start = null;
 
-    /** @var \DateTimeInterface */
-    protected $end;
+    protected ?DateTimeInterface $end = null;
 
-    /** @var int */
-    protected $index;
+    protected int $index;
 
-    public function __construct(\DateTimeInterface $start = null, \DateTimeInterface $end = null, $index = 0)
+    public function __construct(?DateTimeInterface $start = null, ?DateTimeInterface $end = null, $index = 0)
     {
-        if ($start instanceof \DateTimeInterface) {
+        if ($start instanceof DateTimeInterface) {
             $this->setStart($start);
         }
 
-        if ($end instanceof \DateTimeInterface) {
+        if ($end instanceof DateTimeInterface) {
             $this->setEnd($end);
         }
 
         $this->index = $index;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getStart()
+    public function getStart(): ?DateTimeInterface
     {
         return $this->start;
     }
 
-    /**
-     * @param \DateTime $start
-     */
-    public function setStart($start)
+    public function setStart(?DateTimeInterface $start)
     {
         $this->start = $start;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getEnd()
+    public function getEnd(): ?DateTimeInterface
     {
         return $this->end;
     }
 
-    /**
-     * @param \DateTime $end
-     */
-    public function setEnd($end)
+    public function setEnd(?DateTimeInterface $end): void
     {
         $this->end = $end;
     }
 
-    /**
-     * @return int
-     */
-    public function getIndex()
+    public function getIndex(): int
     {
         return $this->index;
     }
 
-    /**
-     * @param int $index
-     */
-    public function setIndex($index)
+    public function setIndex(int $index): void
     {
         $this->index = $index;
     }

--- a/src/Recurr/RecurrenceCollection.php
+++ b/src/Recurr/RecurrenceCollection.php
@@ -9,7 +9,8 @@
 
 namespace Recurr;
 
-use \Doctrine\Common\Collections\ArrayCollection as BaseCollection;
+use DateTimeInterface;
+use Doctrine\Common\Collections\ArrayCollection as BaseCollection;
 
 /**
  * @package Recurr
@@ -18,13 +19,13 @@ use \Doctrine\Common\Collections\ArrayCollection as BaseCollection;
 class RecurrenceCollection extends BaseCollection
 {
     /**
-     * @param \DateTimeInterface $after
-     * @param \DateTimeInterface $before
+     * @param DateTimeInterface $after
+     * @param DateTimeInterface $before
      * @param bool      $inc Include $after or $before if they happen to be a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function startsBetween(\DateTimeInterface $after, \DateTimeInterface $before, $inc = false)
+    public function startsBetween(DateTimeInterface $after, DateTimeInterface $before, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($after, $before, $inc) {
@@ -41,12 +42,12 @@ class RecurrenceCollection extends BaseCollection
     }
 
     /**
-     * @param \DateTimeInterface $before
+     * @param DateTimeInterface $before
      * @param bool               $inc Include $before if it is a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function startsBefore(\DateTimeInterface $before, $inc = false)
+    public function startsBefore(DateTimeInterface $before, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($before, $inc) {
@@ -63,12 +64,12 @@ class RecurrenceCollection extends BaseCollection
     }
 
     /**
-     * @param \DateTimeInterface $after
+     * @param DateTimeInterface $after
      * @param bool               $inc Include $after if it a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function startsAfter(\DateTimeInterface $after, $inc = false)
+    public function startsAfter(DateTimeInterface $after, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($after, $inc) {
@@ -85,13 +86,13 @@ class RecurrenceCollection extends BaseCollection
     }
 
     /**
-     * @param \DateTimeInterface $after
-     * @param \DateTimeInterface $before
+     * @param DateTimeInterface $after
+     * @param DateTimeInterface $before
      * @param bool               $inc Include $after or $before if they happen to be a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function endsBetween(\DateTimeInterface $after, \DateTimeInterface $before, $inc = false)
+    public function endsBetween(DateTimeInterface $after, DateTimeInterface $before, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($after, $before, $inc) {
@@ -108,12 +109,12 @@ class RecurrenceCollection extends BaseCollection
     }
 
     /**
-     * @param \DateTimeInterface $before
+     * @param DateTimeInterface $before
      * @param bool               $inc Include $before if it is a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function endsBefore(\DateTimeInterface $before, $inc = false)
+    public function endsBefore(DateTimeInterface $before, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($before, $inc) {
@@ -130,12 +131,12 @@ class RecurrenceCollection extends BaseCollection
     }
 
     /**
-     * @param \DateTimeInterface $after
+     * @param DateTimeInterface $after
      * @param bool               $inc Include $after if it a recurrence.
      *
      * @return RecurrenceCollection
      */
-    public function endsAfter(\DateTimeInterface $after, $inc = false)
+    public function endsAfter(DateTimeInterface $after, bool $inc = false): self
     {
         return $this->filter(
             function ($recurrence) use ($after, $inc) {

--- a/src/Recurr/Time.php
+++ b/src/Recurr/Time.php
@@ -21,16 +21,13 @@ namespace Recurr;
  */
 class Time
 {
-    /** @var int */
-    public $hour;
+    public int $hour;
 
-    /** @var int */
-    public $minute;
+    public int $minute;
 
-    /** @var int */
-    public $second;
+    public int $second;
 
-    public function __construct($hour, $minute, $second)
+    public function __construct(int $hour, int $minute, int $second)
     {
         $this->hour   = $hour;
         $this->minute = $minute;

--- a/src/Recurr/Transformer/ArrayTransformerConfig.php
+++ b/src/Recurr/Transformer/ArrayTransformerConfig.php
@@ -11,10 +11,9 @@ namespace Recurr\Transformer;
 
 class ArrayTransformerConfig
 {
-    /** @var int */
-    protected $virtualLimit = 732;
+    protected int $virtualLimit = 732;
 
-    protected $lastDayOfMonthFix = false;
+    protected bool $lastDayOfMonthFix = false;
 
     /**
      * Set the virtual limit imposed upon infinitely recurring events.
@@ -23,9 +22,9 @@ class ArrayTransformerConfig
      *
      * @return $this
      */
-    public function setVirtualLimit($virtualLimit)
+    public function setVirtualLimit(int $virtualLimit): self
     {
-        $this->virtualLimit = (int) $virtualLimit;
+        $this->virtualLimit = $virtualLimit;
 
         return $this;
     }
@@ -35,7 +34,7 @@ class ArrayTransformerConfig
      *
      * @return int
      */
-    public function getVirtualLimit()
+    public function getVirtualLimit(): int
     {
         return $this->virtualLimit;
     }
@@ -45,20 +44,17 @@ class ArrayTransformerConfig
      *
      * Enabling this fix tells Recurr that +1 month means "last day of next month".
      */
-    public function enableLastDayOfMonthFix()
+    public function enableLastDayOfMonthFix(): void
     {
         $this->lastDayOfMonthFix = true;
     }
 
-    public function disableLastDayOfMonthFix()
+    public function disableLastDayOfMonthFix(): void
     {
         $this->lastDayOfMonthFix = false;
     }
 
-    /**
-     * @return boolean
-     */
-    public function isLastDayOfMonthFixEnabled()
+    public function isLastDayOfMonthFixEnabled(): bool
     {
         return $this->lastDayOfMonthFix;
     }

--- a/src/Recurr/Transformer/Constraint.php
+++ b/src/Recurr/Transformer/Constraint.php
@@ -11,10 +11,9 @@ namespace Recurr\Transformer;
 
 abstract class Constraint implements ConstraintInterface
 {
+    protected bool $stopsTransformer = true;
 
-    protected $stopsTransformer = true;
-
-    public function stopsTransformer()
+    public function stopsTransformer(): bool
     {
         return $this->stopsTransformer;
     }

--- a/src/Recurr/Transformer/Constraint/AfterConstraint.php
+++ b/src/Recurr/Transformer/Constraint/AfterConstraint.php
@@ -9,24 +9,22 @@
 
 namespace Recurr\Transformer\Constraint;
 
+use DateTimeInterface;
 use Recurr\Transformer\Constraint;
 
 class AfterConstraint extends Constraint
 {
+    protected bool $stopsTransformer = false;
 
-    protected $stopsTransformer = false;
+    protected DateTimeInterface $after;
 
-    /** @var \DateTimeInterface */
-    protected $after;
-
-    /** @var bool */
-    protected $inc;
+    protected bool $inc;
 
     /**
-     * @param \DateTimeInterface $after
+     * @param DateTimeInterface $after
      * @param bool               $inc Include date if it equals $after.
      */
-    public function __construct(\DateTimeInterface $after, $inc = false)
+    public function __construct(DateTimeInterface $after, bool $inc = false)
     {
         $this->after = $after;
         $this->inc    = $inc;
@@ -34,10 +32,8 @@ class AfterConstraint extends Constraint
 
     /**
      * Passes if $date is after $after
-     *
-     * {@inheritdoc}
      */
-    public function test(\DateTimeInterface $date)
+    public function test(DateTimeInterface $date): bool
     {
         if ($this->inc) {
             return $date >= $this->after;
@@ -46,18 +42,12 @@ class AfterConstraint extends Constraint
         return $date > $this->after;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getAfter()
+    public function getAfter(): DateTimeInterface
     {
         return $this->after;
     }
 
-    /**
-     * @return bool
-     */
-    public function isInc()
+    public function isInc(): bool
     {
         return $this->inc;
     }

--- a/src/Recurr/Transformer/Constraint/BeforeConstraint.php
+++ b/src/Recurr/Transformer/Constraint/BeforeConstraint.php
@@ -9,24 +9,22 @@
 
 namespace Recurr\Transformer\Constraint;
 
+use DateTimeInterface;
 use Recurr\Transformer\Constraint;
 
 class BeforeConstraint extends Constraint
 {
+    protected bool $stopsTransformer = true;
 
-    protected $stopsTransformer = true;
+    protected DateTimeInterface $before;
 
-    /** @var \DateTimeInterface */
-    protected $before;
-
-    /** @var bool */
-    protected $inc;
+    protected bool $inc;
 
     /**
-     * @param \DateTimeInterface $before
+     * @param DateTimeInterface $before
      * @param bool               $inc Include date if it equals $before.
      */
-    public function __construct(\DateTimeInterface $before, $inc = false)
+    public function __construct(DateTimeInterface $before, bool $inc = false)
     {
         $this->before = $before;
         $this->inc    = $inc;
@@ -34,10 +32,8 @@ class BeforeConstraint extends Constraint
 
     /**
      * Passes if $date is before $before
-     *
-     * {@inheritdoc}
      */
-    public function test(\DateTimeInterface $date)
+    public function test(DateTimeInterface $date): bool
     {
         if ($this->inc) {
             return $date <= $this->before;
@@ -46,18 +42,12 @@ class BeforeConstraint extends Constraint
         return $date < $this->before;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getBefore()
+    public function getBefore(): DateTimeInterface
     {
         return $this->before;
     }
 
-    /**
-     * @return bool
-     */
-    public function isInc()
+    public function isInc(): bool
     {
         return $this->inc;
     }

--- a/src/Recurr/Transformer/Constraint/BetweenConstraint.php
+++ b/src/Recurr/Transformer/Constraint/BetweenConstraint.php
@@ -9,28 +9,25 @@
 
 namespace Recurr\Transformer\Constraint;
 
+use DateTimeInterface;
 use Recurr\Transformer\Constraint;
 
 class BetweenConstraint extends Constraint
 {
+    protected bool $stopsTransformer = false;
 
-    protected $stopsTransformer = false;
+    protected DateTimeInterface $before;
 
-    /** @var \DateTimeInterface */
-    protected $before;
+    protected DateTimeInterface $after;
 
-    /** @var \DateTimeInterface */
-    protected $after;
-
-    /** @var bool */
-    protected $inc;
+    protected bool $inc;
 
     /**
-     * @param \DateTimeInterface $after
-     * @param \DateTimeInterface $before
-     * @param bool               $inc Include date if it equals $after or $before.
+     * @param DateTimeInterface $after
+     * @param DateTimeInterface $before
+     * @param bool              $inc Include date if it equals $after or $before.
      */
-    public function __construct(\DateTimeInterface $after, \DateTimeInterface $before, $inc = false)
+    public function __construct(DateTimeInterface $after, DateTimeInterface $before, bool $inc = false)
     {
         $this->after  = $after;
         $this->before = $before;
@@ -39,10 +36,8 @@ class BetweenConstraint extends Constraint
 
     /**
      * Passes if $date is between $after and $before
-     *
-     * {@inheritdoc}
      */
-    public function test(\DateTimeInterface $date)
+    public function test(DateTimeInterface $date): bool
     {
         if ($date > $this->before) {
             $this->stopsTransformer = true;
@@ -55,26 +50,17 @@ class BetweenConstraint extends Constraint
         return $date > $this->after && $date < $this->before;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getBefore()
+    public function getBefore(): DateTimeInterface
     {
         return $this->before;
     }
 
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getAfter()
+    public function getAfter(): DateTimeInterface
     {
         return $this->after;
     }
 
-    /**
-     * @return bool
-     */
-    public function isInc()
+    public function isInc(): bool
     {
         return $this->inc;
     }

--- a/src/Recurr/Transformer/ConstraintInterface.php
+++ b/src/Recurr/Transformer/ConstraintInterface.php
@@ -9,17 +9,11 @@
 
 namespace Recurr\Transformer;
 
+use DateTimeInterface;
+
 interface ConstraintInterface
 {
-    /**
-     * @return bool
-     */
-    public function stopsTransformer();
+    public function stopsTransformer(): bool;
 
-    /**
-     * @param \DateTimeInterface $date
-     *
-     * @return bool
-     */
-    public function test(\DateTimeInterface $date);
+    public function test(DateTimeInterface $date): bool;
 }

--- a/src/Recurr/Transformer/Translator.php
+++ b/src/Recurr/Transformer/Translator.php
@@ -4,9 +4,9 @@ namespace Recurr\Transformer;
 
 class Translator implements TranslatorInterface
 {
-    protected $data = array();
+    protected array $data = [];
 
-    public function __construct($locale = 'en', $fallbackLocale = 'en')
+    public function __construct(string $locale = 'en', string $fallbackLocale = 'en')
     {
         $this->loadLocale($fallbackLocale);
         if ($locale !== $fallbackLocale) {
@@ -14,19 +14,19 @@ class Translator implements TranslatorInterface
         }
     }
 
-    public function loadLocale($locale, $path = null)
+    public function loadLocale(string $locale, ?string $path = null): void
     {
         if (!$path) {
             $path = __DIR__ . '/../../../translations/' . $locale . '.php';
         }
         if (!file_exists($path)) {
-            throw new \InvalidArgumentException('Locale '.$locale.' could not be found in '.$path);
+            throw new \InvalidArgumentException('Locale ' . $locale . ' could not be found in ' . $path);
         }
 
         $this->data = array_merge($this->data, include $path);
     }
 
-    public function trans($string, array $params = array())
+    public function trans(string $string, array $params = []): string|array
     {
         $res = $this->data[$string];
         if (is_object($res) && is_callable($res)) {

--- a/src/Recurr/Transformer/TranslatorInterface.php
+++ b/src/Recurr/Transformer/TranslatorInterface.php
@@ -4,5 +4,6 @@ namespace Recurr\Transformer;
 
 interface TranslatorInterface
 {
-    public function trans($string);
+    /** @return string|array<string> */
+    public function trans(string $string): string|array;
 }

--- a/src/Recurr/Weekday.php
+++ b/src/Recurr/Weekday.php
@@ -21,7 +21,7 @@ use Recurr\Exception\InvalidWeekday;
  * @package Recurr
  * @author  Shaun Simmons <shaun@envysphere.com>
  */
-class Weekday
+class Weekday implements \Stringable
 {
     /**
      * Weekday number.
@@ -33,15 +33,13 @@ class Weekday
      * 4 = Thursday
      * 5 = Friday
      * 6 = Saturday
-     *
-     * @var string
      */
-    public $weekday;
+    public int $weekday;
 
-    /** @var int nth occurrence of the weekday */
-    public $num;
+    /** @var int|null nth occurrence of the weekday */
+    public ?int $num = null;
 
-    protected $days = array('MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU');
+    protected array $days = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
 
     /**
      * @param int|string $weekday 0-6 or MO..SU
@@ -49,7 +47,7 @@ class Weekday
      *
      * @throws InvalidWeekday
      */
-    public function __construct($weekday, $num)
+    public function __construct(int|string $weekday, ?int $num)
     {
         if (is_numeric($weekday) && $weekday > 6 || $weekday < 0) {
             throw new InvalidWeekday('Day is not a valid weekday (0-6)');
@@ -65,7 +63,7 @@ class Weekday
         $this->num = $num;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->num . $this->days[$this->weekday];
     }

--- a/tests/Recurr/Test/RecurrenceCollectionTest.php
+++ b/tests/Recurr/Test/RecurrenceCollectionTest.php
@@ -2,187 +2,187 @@
 
 namespace Recurr\Test;
 
+use DateTime;
 use Recurr\Recurrence;
 use Recurr\RecurrenceCollection;
 
 class RecurrenceCollectionTest extends \PHPUnit\Framework\TestCase
 {
-    /** @var RecurrenceCollection */
-    protected $collection;
+    protected RecurrenceCollection $collection;
 
     public function setUp(): void
     {
         $this->collection = new RecurrenceCollection(
-            array(
-                new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-                new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-                new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-                new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-                new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-            )
+            [
+                new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+                new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+                new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+                new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+                new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+            ]
         );
     }
 
-    public function testStartsBetween()
+    public function testStartsBetween(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+        ];
 
-        $after  = new \DateTime('2014-01-01');
-        $before = new \DateTime('2014-05-01');
+        $after  = new DateTime('2014-01-01');
+        $before = new DateTime('2014-05-01');
         $result = $this->collection->startsBetween($after, $before);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testStartsBetweenInc()
+    public function testStartsBetweenInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $after  = new \DateTime('2014-01-01');
-        $before = new \DateTime('2014-05-01');
+        $after  = new DateTime('2014-01-01');
+        $before = new DateTime('2014-05-01');
         $result = $this->collection->startsBetween($after, $before, true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testStartsBefore()
+    public function testStartsBefore(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+        ];
 
-        $result = $this->collection->startsBefore(new \DateTime('2014-03-01'));
+        $result = $this->collection->startsBefore(new DateTime('2014-03-01'));
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testStartsBeforeInc()
+    public function testStartsBeforeInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+        ];
 
-        $result = $this->collection->startsBefore(new \DateTime('2014-03-01'), true);
+        $result = $this->collection->startsBefore(new DateTime('2014-03-01'), true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testStartsAfter()
+    public function testStartsAfter(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $result = $this->collection->startsAfter(new \DateTime('2014-03-01'));
+        $result = $this->collection->startsAfter(new DateTime('2014-03-01'));
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testStartsAfterInc()
+    public function testStartsAfterInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $result = $this->collection->startsAfter(new \DateTime('2014-03-01'), true);
+        $result = $this->collection->startsAfter(new DateTime('2014-03-01'), true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsBetween()
+    public function testEndsBetween(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+        ];
 
-        $after  = new \DateTime('2014-01-15');
-        $before = new \DateTime('2014-05-15');
+        $after  = new DateTime('2014-01-15');
+        $before = new DateTime('2014-05-15');
         $result = $this->collection->endsBetween($after, $before);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsBetweenInc()
+    public function testEndsBetweenInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $after  = new \DateTime('2014-01-15');
-        $before = new \DateTime('2014-05-15');
+        $after  = new DateTime('2014-01-15');
+        $before = new DateTime('2014-05-15');
         $result = $this->collection->endsBetween($after, $before, true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsBefore()
+    public function testEndsBefore(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+        ];
 
-        $result = $this->collection->endsBefore(new \DateTime('2014-03-15'));
+        $result = $this->collection->endsBefore(new DateTime('2014-03-15'));
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsBeforeInc()
+    public function testEndsBeforeInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-01-01'), new \DateTime('2014-01-15')),
-            new Recurrence(new \DateTime('2014-02-01'), new \DateTime('2014-02-15')),
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-01-01'), new DateTime('2014-01-15')),
+            new Recurrence(new DateTime('2014-02-01'), new DateTime('2014-02-15')),
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+        ];
 
-        $result = $this->collection->endsBefore(new \DateTime('2014-03-15'), true);
+        $result = $this->collection->endsBefore(new DateTime('2014-03-15'), true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsAfter()
+    public function testEndsAfter(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $result = $this->collection->endsAfter(new \DateTime('2014-03-15'));
+        $result = $this->collection->endsAfter(new DateTime('2014-03-15'));
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }
 
-    public function testEndsAfterInc()
+    public function testEndsAfterInc(): void
     {
-        $expected = array(
-            new Recurrence(new \DateTime('2014-03-01'), new \DateTime('2014-03-15')),
-            new Recurrence(new \DateTime('2014-04-01'), new \DateTime('2014-04-15')),
-            new Recurrence(new \DateTime('2014-05-01'), new \DateTime('2014-05-15')),
-        );
+        $expected = [
+            new Recurrence(new DateTime('2014-03-01'), new DateTime('2014-03-15')),
+            new Recurrence(new DateTime('2014-04-01'), new DateTime('2014-04-15')),
+            new Recurrence(new DateTime('2014-05-01'), new DateTime('2014-05-15')),
+        ];
 
-        $result = $this->collection->endsAfter(new \DateTime('2014-03-15'), true);
+        $result = $this->collection->endsAfter(new DateTime('2014-03-15'), true);
 
         $this->assertEquals($expected, array_values($result->toArray()));
     }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerBase.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerBase.php
@@ -2,14 +2,16 @@
 
 namespace Recurr\Test\Transformer;
 
+use PHPUnit\Framework\TestCase;
 use Recurr\Transformer\ArrayTransformer;
 
-class ArrayTransformerBase extends \PHPUnit\Framework\TestCase
+class ArrayTransformerBase extends TestCase
 {
-    /** @var ArrayTransformer */
-    protected $transformer;
+    protected ArrayTransformer $transformer;
 
-    protected $timezone = 'America/New_York';
+    protected string $timezone = 'America/New_York';
+
+    protected array $defaults = ['FREQ' => 'DAILY'];
 
     public function setUp(): void
     {

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByDayTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByDayTest.php
@@ -2,38 +2,38 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
+use DateTimeZone;
+use Recurr\Exception\InvalidRRule;
 use Recurr\Rule;
 
 class ArrayTransformerByDayTest extends ArrayTransformerBase
 {
-    public function testByDayWeekly()
+    public function testByDayWeekly(): void
     {
-        $rule = new Rule(
-            'FREQ=WEEKLY;COUNT=10;INTERVAL=2;BYDAY=MO,WE,FR',
-            new \DateTime('1997-09-02 16:00:00')
-        );
+        $rule = new Rule('FREQ=WEEKLY;COUNT=10;INTERVAL=2;BYDAY=MO,WE,FR', new \DateTime('1997-09-02 16:00:00'));
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertEquals(10, count($computed));
-        $this->assertEquals(new \DateTime('1997-09-03 16:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('1997-09-05 16:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('1997-09-15 16:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('1997-09-17 16:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('1997-09-19 16:00:00'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('1997-09-29 16:00:00'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('1997-10-01 16:00:00'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('1997-10-03 16:00:00'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('1997-10-13 16:00:00'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('1997-10-15 16:00:00'), $computed[9]->getStart());
+        $this->assertEquals(new DateTime('1997-09-03 16:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('1997-09-05 16:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('1997-09-15 16:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('1997-09-17 16:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('1997-09-19 16:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('1997-09-29 16:00:00'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('1997-10-01 16:00:00'), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('1997-10-03 16:00:00'), $computed[7]->getStart());
+        $this->assertEquals(new DateTime('1997-10-13 16:00:00'), $computed[8]->getStart());
+        $this->assertEquals(new DateTime('1997-10-15 16:00:00'), $computed[9]->getStart());
     }
 
-    public function testByDayWeeklyAcrossUKBST()
+    public function testByDayWeeklyAcrossUKBST(): void
     {
-              $rule = new Rule(
+        $rule = new Rule(
             'FREQ=WEEKLY;COUNT=10;BYDAY=WE',
-            new \DateTime('2015-03-01 16:00:00', new \DateTimeZone('Europe/London')),
-            new \DateTime('2015-03-01 17:00:00', new \DateTimeZone('Europe/London')),
+            new DateTime('2015-03-01 16:00:00', new DateTimeZone('Europe/London')),
+            new DateTime('2015-03-01 17:00:00', new DateTimeZone('Europe/London')),
             'Europe/London'
         );
 
@@ -41,74 +41,74 @@ class ArrayTransformerByDayTest extends ArrayTransformerBase
 
         $this->assertEquals(10, count($computed));
         $this->assertEquals('Europe/London', $computed[0]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-03-04 16:00:00', new \DateTimeZone('UTC')), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2015-03-04 16:00:00', new DateTimeZone('UTC')), $computed[0]->getStart());
         $this->assertEquals('Europe/London', $computed[1]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-03-11 16:00:00', new \DateTimeZone('UTC')), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2015-03-11 16:00:00', new DateTimeZone('UTC')), $computed[1]->getStart());
         $this->assertEquals('Europe/London', $computed[2]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-03-18 16:00:00', new \DateTimeZone('UTC')), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2015-03-18 16:00:00', new DateTimeZone('UTC')), $computed[2]->getStart());
         $this->assertEquals('Europe/London', $computed[3]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-03-25 16:00:00', new \DateTimeZone('UTC')), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2015-03-25 16:00:00', new DateTimeZone('UTC')), $computed[3]->getStart());
         // UK BST change happens here. Should change
         // to be honest, not sure if it should be 15 or 17 but def should NOT be 16.
         $this->assertEquals('Europe/London', $computed[4]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-04-01 15:00:00', new \DateTimeZone('UTC')), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2015-04-01 15:00:00', new DateTimeZone('UTC')), $computed[4]->getStart());
         $this->assertEquals('Europe/London', $computed[5]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-04-08 15:00:00', new \DateTimeZone('UTC')), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2015-04-08 15:00:00', new DateTimeZone('UTC')), $computed[5]->getStart());
         $this->assertEquals('Europe/London', $computed[6]->getStart()->getTimezone()->getName());
-        $this->assertEquals(new \DateTime('2015-04-15 15:00:00', new \DateTimeZone('UTC')), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('2015-04-15 15:00:00', new DateTimeZone('UTC')), $computed[6]->getStart());
     }
 
-    public function testByDayMonthly()
+    public function testByDayMonthly(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=10;BYDAY=WE,TH',
-            new \DateTime('2014-01-14 16:00:00')
+            new DateTime('2014-01-14 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertEquals(10, count($computed));
-        $this->assertEquals(new \DateTime('2014-01-15 16:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-16 16:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-22 16:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-23 16:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-29 16:00:00'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-30 16:00:00'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-05 16:00:00'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-06 16:00:00'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-12 16:00:00'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-13 16:00:00'), $computed[9]->getStart());
+        $this->assertEquals(new DateTime('2014-01-15 16:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-01-16 16:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-01-22 16:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-01-23 16:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-29 16:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-01-30 16:00:00'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2014-02-05 16:00:00'), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('2014-02-06 16:00:00'), $computed[7]->getStart());
+        $this->assertEquals(new DateTime('2014-02-12 16:00:00'), $computed[8]->getStart());
+        $this->assertEquals(new DateTime('2014-02-13 16:00:00'), $computed[9]->getStart());
     }
 
-    public function testByDayYearly()
+    public function testByDayYearly(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=3;BYDAY=20MO',
-            new \DateTime('1997-05-19 16:00:00')
+            new DateTime('1997-05-19 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertEquals(3, count($computed));
-        $this->assertEquals(new \DateTime('1997-05-19 16:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('1998-05-18 16:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('1999-05-17 16:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('1997-05-19 16:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('1998-05-18 16:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('1999-05-17 16:00:00'), $computed[2]->getStart());
     }
 
     /**
      * @dataProvider unsupportedNthByDayFrequencies
      */
-    public function testNthByDayWithUnsupportedFrequency($frequency)
+    public function testNthByDayWithUnsupportedFrequency($frequency): void
     {
-        $this->expectException(\Recurr\Exception\InvalidRRule::class);
+        $this->expectException(InvalidRRule::class);
         new Rule(
             "FREQ=$frequency;COUNT=3;BYDAY=2MO",
-            new \DateTime('1997-05-19 16:00:00')
+            new DateTime('1997-05-19 16:00:00')
         );
     }
 
-    public function unsupportedNthByDayFrequencies()
+    public function unsupportedNthByDayFrequencies(): array
     {
-        return array(array('DAILY'), array('HOURLY'), array('MINUTELY'), array('SECONDLY'));
+        return [['DAILY'], ['HOURLY'], ['MINUTELY'], ['SECONDLY']];
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByHourTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByHourTest.php
@@ -2,50 +2,51 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerByHourTest extends ArrayTransformerBase
 {
-    public function testByHourHourly()
+    public function testByHourHourly(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-13 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-15 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-15 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testByHourDaily()
+    public function testByHourDaily(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-13 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-15 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-15 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testByHourWithVirtualLimit()
+    public function testByHourWithVirtualLimit(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;BYHOUR=13',
-            new \DateTime('2014-06-12 15:00:00')
+            new DateTime('2014-06-12 15:00:00')
         );
 
         $config = new ArrayTransformerConfig();
@@ -55,105 +56,105 @@ class ArrayTransformerByHourTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(2, $computed);
-        $this->assertEquals(new \DateTime('2014-06-13 13:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-14 13:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-06-13 13:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-06-14 13:00:00'), $computed[1]->getStart());
     }
 
-    public function testByHourWeekly()
+    public function testByHourWeekly(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-19 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-19 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-26 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-26 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-03 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-26 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-26 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-07-03 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testByHourMonthly()
+    public function testByHourMonthly(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-07-12 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-12 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-08-12 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-08-12 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-09-12 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-08-12 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-08-12 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-09-12 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testByHourMonthlyLeapYear()
+    public function testByHourMonthlyLeapYear(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2016-01-29 12:00:00')
+            new DateTime('2016-01-29 12:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-01-29 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-01-29 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-29 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-01-29 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-01-29 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-03-29 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testByHourYearly()
+    public function testByHourYearly(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYHOUR=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2014-06-12 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-12 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2015-06-12 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2015-06-12 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-06-12 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2015-06-12 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2015-06-12 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-06-12 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testYearlyOnLeapYear()
+    public function testYearlyOnLeapYear(): void
     {
-        $rule = new Rule('FREQ=YEARLY;COUNT=5;BYHOUR=14,15', new \DateTime('2016-02-29 12:00:00'));
+        $rule = new Rule('FREQ=YEARLY;COUNT=5;BYHOUR=14,15', new DateTime('2016-02-29 12:00:00'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2020-02-29 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2020-02-29 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2024-02-29 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2020-02-29 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2020-02-29 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2024-02-29 14:00:00'), $computed[4]->getStart());
     }
 
-    public function testYearlyOnLeapYearWithLastDayOfMonthFix()
+    public function testYearlyOnLeapYearWithLastDayOfMonthFix(): void
     {
         $transformerConfig = new ArrayTransformerConfig();
         $transformerConfig->enableLastDayOfMonthFix();
         $this->transformer->setConfig($transformerConfig);
 
-        $rule = new Rule('FREQ=YEARLY;COUNT=5;BYHOUR=14,15', new \DateTime('2016-02-29 12:00:00'));
+        $rule = new Rule('FREQ=YEARLY;COUNT=5;BYHOUR=14,15', new DateTime('2016-02-29 12:00:00'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29 14:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 15:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2017-02-28 14:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2017-02-28 15:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2018-02-28 14:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 14:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 15:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2017-02-28 14:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2017-02-28 15:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2018-02-28 14:00:00'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByMinuteTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByMinuteTest.php
@@ -2,109 +2,110 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerByMinuteTest extends ArrayTransformerBase
 {
-    public function testByMinuteMinutely()
+    public function testByMinuteMinutely(): void
     {
         $rule = new Rule(
             'FREQ=MINUTELY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 18:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 18:14:00'), $computed[4]->getStart());
     }
 
-    public function testByMinuteHourly()
+    public function testByMinuteHourly(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 18:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 18:14:00'), $computed[4]->getStart());
     }
 
-    public function testByMinuteDaily()
+    public function testByMinuteDaily(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 16:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 16:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 16:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 16:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 16:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 16:14:00'), $computed[4]->getStart());
     }
 
-    public function testByMinuteWeekly()
+    public function testByMinuteWeekly(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-19 16:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-19 16:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-26 16:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 16:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 16:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-26 16:14:00'), $computed[4]->getStart());
     }
 
-    public function testByMinuteMonthly()
+    public function testByMinuteMonthly(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-12 16:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-12 16:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-08-12 16:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 16:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 16:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-08-12 16:14:00'), $computed[4]->getStart());
     }
 
-    public function testByMinuteYearly()
+    public function testByMinuteYearly(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYMINUTE=14,15',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-12 16:14:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-12 16:15:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2015-06-12 16:14:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:14:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:15:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 16:14:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 16:15:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2015-06-12 16:14:00'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByMonthDayTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByMonthDayTest.php
@@ -2,90 +2,91 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerByMonthDayTest extends ArrayTransformerBase
 {
-    public function testByMonthDayMonthly()
+    public function testByMonthDayMonthly(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMONTHDAY=28,29,30',
-            new \DateTime('2013-01-30')
+            new DateTime('2013-01-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-29'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-30'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-03-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-03-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-03-30'), $computed[4]->getStart());
     }
 
-    public function testByMonthDayMonthlyNegative()
+    public function testByMonthDayMonthlyNegative(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMONTHDAY=-10',
-            new \DateTime('2013-06-07')
+            new DateTime('2013-06-07')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-21'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-22'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-08-22'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-09-21'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-10-22'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-21'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-07-22'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-08-22'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-09-21'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-10-22'), $computed[4]->getStart());
     }
 
-    public function testByMonthDayMonthlyPositiveAndNegative()
+    public function testByMonthDayMonthlyPositiveAndNegative(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMONTHDAY=15,-1',
-            new \DateTime('2013-10-01')
+            new DateTime('2013-10-01')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-10-15'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-10-31'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-11-15'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-11-30'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-12-15'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-10-15'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-10-31'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-11-15'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-11-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-12-15'), $computed[4]->getStart());
     }
 
-    public function testByMonthDayMonthlyLeapYear()
+    public function testByMonthDayMonthlyLeapYear(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMONTHDAY=28,29,30',
-            new \DateTime('2016-01-30')
+            new DateTime('2016-01-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-28'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-29'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-03-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-03-29'), $computed[4]->getStart());
     }
 
-    public function testByMonthDayYearlyWithByMonthAndByDay()
+    public function testByMonthDayYearlyWithByMonthAndByDay(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=3;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8',
-            new \DateTime('1996-11-05 09:00:00')
+            new DateTime('1996-11-05 09:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(3, $computed);
-        $this->assertEquals(new \DateTime('1996-11-05 09:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2000-11-07 09:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2004-11-02 09:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('1996-11-05 09:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2000-11-07 09:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2004-11-02 09:00:00'), $computed[2]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByMonthTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByMonthTest.php
@@ -2,39 +2,40 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerByMonthTest extends ArrayTransformerBase
 {
-    public function testByMonth()
+    public function testByMonth(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=4;BYMONTH=2,3',
-            new \DateTime('2013-02-26')
+            new DateTime('2013-02-26')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2013-02-26'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-27'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-02-26'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-02-27'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01'), $computed[3]->getStart());
     }
 
-    public function testByMonthLeapYear()
+    public function testByMonthLeapYear(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=4;BYMONTH=2,3',
-            new \DateTime('2016-02-27')
+            new DateTime('2016-02-27')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-02-27'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-02-27'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01'), $computed[3]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerBySecondTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerBySecondTest.php
@@ -2,126 +2,127 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerBySecondTest extends ArrayTransformerBase
 {
-    public function testBySecondSecondly()
+    public function testBySecondSecondly(): void
     {
         $rule = new Rule(
             'FREQ=SECONDLY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:01:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:01:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:02:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:01:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:01:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:02:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondMinutely()
+    public function testBySecondMinutely(): void
     {
         $rule = new Rule(
             'FREQ=MINUTELY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:01:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:01:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:02:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:01:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:01:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:02:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondHourly()
+    public function testBySecondHourly(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:00:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 17:00:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 18:00:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:00:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 17:00:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 18:00:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondDaily()
+    public function testBySecondDaily(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 16:00:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-13 16:00:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-14 16:00:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 16:00:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 16:00:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-14 16:00:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondWeekly()
+    public function testBySecondWeekly(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-19 16:00:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-19 16:00:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-26 16:00:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 16:00:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-19 16:00:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-06-26 16:00:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondMonthly()
+    public function testBySecondMonthly(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-12 16:00:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-12 16:00:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-08-12 16:00:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 16:00:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-07-12 16:00:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-08-12 16:00:36'), $computed[4]->getStart());
     }
 
-    public function testBySecondYearly()
+    public function testBySecondYearly(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYSECOND=36,45',
-            new \DateTime('2013-06-12 16:00:00')
+            new DateTime('2013-06-12 16:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-12 16:00:36'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-12 16:00:45'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2015-06-12 16:00:36'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:36'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-12 16:00:45'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 16:00:36'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-06-12 16:00:45'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2015-06-12 16:00:36'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerBySetPositionTest.php
@@ -2,82 +2,83 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
 {
-    public function testBySetPosition()
+    public function testBySetPosition(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR;COUNT=5',
-            new \DateTime('2013-01-24')
+            new DateTime('2013-01-24')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-04-30'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-05-31'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-03-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-04-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-05-31'), $computed[4]->getStart());
 
         // --------------------------------------
 
         $rule = new Rule(
             'FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR;COUNT=5',
-            new \DateTime('2016-01-24')
+            new DateTime('2016-01-24')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-29'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-05-31'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-05-31'), $computed[4]->getStart());
 
         // --------------------------------------
 
         $rule = new Rule(
             'FREQ=MONTHLY;BYSETPOS=1,-1;BYDAY=MO,TU,WE,TH,FR;COUNT=5',
-            new \DateTime('2016-01-24')
+            new DateTime('2016-01-24')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-01'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-31'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-01'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-03-31'), $computed[4]->getStart());
 
         // --------------------------------------
 
         $rule = new Rule(
             'FREQ=MONTHLY;BYSETPOS=5;BYDAY=SU;UNTIL=2018-08-01',
-            new \DateTime('2017-04-30')
+            new DateTime('2017-04-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(6, $computed);
-        $this->assertEquals(new \DateTime('2017-04-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2017-07-30'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2017-10-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-31'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2018-04-29'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2018-07-29'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2017-04-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2017-07-30'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2017-10-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2017-12-31'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2018-04-29'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2018-07-29'), $computed[5]->getStart());
     }
 
-    public function testBySetPositionVirtualLimit()
+    public function testBySetPositionVirtualLimit(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR',
-            new \DateTime('2013-01-24')
+            new DateTime('2013-01-24')
         );
 
         $config = new ArrayTransformerConfig();
@@ -87,40 +88,40 @@ class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-04-30'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-05-31'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-03-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-04-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-05-31'), $computed[4]->getStart());
     }
 
-    public function testBySetPositionWithInterval()
+    public function testBySetPositionWithInterval(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;INTERVAL=2;BYDAY=MO;BYSETPOS=2;COUNT=10',
-            new \DateTime('2013-10-09')
+            new DateTime('2013-10-09')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(10, $computed);
-        $this->assertEquals(new \DateTime('2013-10-14'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-12-09'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-10'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-14'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-09'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2014-08-11'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('2014-10-13'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('2014-12-08'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('2015-02-09'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('2015-04-13'), $computed[9]->getStart());
+        $this->assertEquals(new DateTime('2013-10-14'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-12-09'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-02-10'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-14'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-06-09'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-08-11'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2014-10-13'), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('2014-12-08'), $computed[7]->getStart());
+        $this->assertEquals(new DateTime('2015-02-09'), $computed[8]->getStart());
+        $this->assertEquals(new DateTime('2015-04-13'), $computed[9]->getStart());
     }
 
-    public function testNoIndexErrorOnEmptySet()
+    public function testNoIndexErrorOnEmptySet(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
-            new \DateTime('2017-07-01')
+            new DateTime('2017-07-01')
         );
 
         $computed = $this->transformer->transform($rule);
@@ -128,33 +129,33 @@ class ArrayTransformerBySetPositionTest extends ArrayTransformerBase
         $this->assertCount(18, $computed);
     }
 
-    public function testBySetPositionHandlesMultipleNegatives()
+    public function testBySetPositionHandlesMultipleNegatives(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;UNTIL=20180102T120000Z;BYDAY=TH,FR;BYMONTH=11,12;BYSETPOS=-1,-2',
-            new \DateTime('2017-11-01')
+            new DateTime('2017-11-01')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(18, $computed);
-        $this->assertEquals(new \DateTime('2017-11-02'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-03'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-09'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-10'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-16'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-17'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-23'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-24'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('2017-11-30'), $computed[9]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-01'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-07'), $computed[11]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-08'), $computed[10]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-14'), $computed[13]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-15'), $computed[12]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-21'), $computed[15]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-22'), $computed[14]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-28'), $computed[17]->getStart());
-        $this->assertEquals(new \DateTime('2017-12-29'), $computed[16]->getStart());
+        $this->assertEquals(new DateTime('2017-11-02'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2017-11-03'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2017-11-09'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2017-11-10'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2017-11-16'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2017-11-17'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2017-11-23'), $computed[7]->getStart());
+        $this->assertEquals(new DateTime('2017-11-24'), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('2017-11-30'), $computed[9]->getStart());
+        $this->assertEquals(new DateTime('2017-12-01'), $computed[8]->getStart());
+        $this->assertEquals(new DateTime('2017-12-07'), $computed[11]->getStart());
+        $this->assertEquals(new DateTime('2017-12-08'), $computed[10]->getStart());
+        $this->assertEquals(new DateTime('2017-12-14'), $computed[13]->getStart());
+        $this->assertEquals(new DateTime('2017-12-15'), $computed[12]->getStart());
+        $this->assertEquals(new DateTime('2017-12-21'), $computed[15]->getStart());
+        $this->assertEquals(new DateTime('2017-12-22'), $computed[14]->getStart());
+        $this->assertEquals(new DateTime('2017-12-28'), $computed[17]->getStart());
+        $this->assertEquals(new DateTime('2017-12-29'), $computed[16]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByWeekDayTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByWeekDayTest.php
@@ -6,7 +6,7 @@ use Recurr\Rule;
 
 class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
 {
-    public function testByWeekDay()
+    public function testByWeekDay(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;BYDAY=MO,TU',
@@ -23,7 +23,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2013-02-11'), $computed[4]->getStart());
     }
 
-    public function testByWeekDayWeeklyWithInterval2()
+    public function testByWeekDayWeeklyWithInterval2(): void
     {
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;INTERVAL=2;BYDAY=TU,WE;WKST=WE',
@@ -56,7 +56,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2013-03-05'), $computed[4]->getStart());
     }
 
-    public function testByWeekDayMonthlyRelativeFromStart()
+    public function testByWeekDayMonthlyRelativeFromStart(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYDAY=+1MO',
@@ -73,7 +73,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2013-11-04'), $computed[4]->getStart());
     }
 
-    public function testByWeekDayMonthlyRelativeFromEnd()
+    public function testByWeekDayMonthlyRelativeFromEnd(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYDAY=-1MO',
@@ -106,7 +106,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2014-06-02'), $computed[4]->getStart());
     }
 
-    public function testByWeekDayMonthlyRelativeFromStartAndEnd()
+    public function testByWeekDayMonthlyRelativeFromStartAndEnd(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=10;BYDAY=-1MO,3FR',
@@ -128,7 +128,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2013-10-28'), $computed[9]->getStart());
     }
 
-    public function testByWeekDayMonthlyWithSundayStartOfYear()
+    public function testByWeekDayMonthlyWithSundayStartOfYear(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=6;BYDAY=MO',
@@ -163,7 +163,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2017-03-17'), $computed[5]->getStart());
     }
 
-    public function testByWeekDayYearlyRelativeFromStart()
+    public function testByWeekDayYearlyRelativeFromStart(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYDAY=+1MO',
@@ -180,7 +180,7 @@ class ArrayTransformerByWeekDayTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2018-01-01'), $computed[4]->getStart());
     }
 
-    public function testByWeekDayYearlyRelativeFromEnd()
+    public function testByWeekDayYearlyRelativeFromEnd(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYDAY=-1MO',

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByWeekNumberTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByWeekNumberTest.php
@@ -2,75 +2,76 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerByWeekNumberTest extends ArrayTransformerBase
 {
-    public function testByWeekNumber()
+    public function testByWeekNumber(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYWEEKNO=22;WKST=SU',
-            new \DateTime('2013-05-30')
+            new DateTime('2013-05-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-05-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-05-31'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-01'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-25'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-26'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-05-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-05-31'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-01'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-05-25'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-05-26'), $computed[4]->getStart());
     }
 
-    public function testByWeekNumberNegative()
+    public function testByWeekNumberNegative(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYWEEKNO=-44;WKST=TH',
-            new \DateTime('2013-05-30')
+            new DateTime('2013-05-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2014-02-27'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-01'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-02'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-03'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-02-27'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-01'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-03-02'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-03-03'), $computed[4]->getStart());
     }
 
-    public function testByWeekNumberWeek53()
+    public function testByWeekNumberWeek53(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYWEEKNO=53;WKST=MO',
-            new \DateTime('2013-05-30')
+            new DateTime('2013-05-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2015-12-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2015-12-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2015-12-30'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2015-12-31'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-01-01'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2015-12-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2015-12-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2015-12-30'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2015-12-31'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-01'), $computed[4]->getStart());
     }
 
-    public function testByWeekNumberWeek53Negative()
+    public function testByWeekNumberWeek53Negative(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=5;BYWEEKNO=-53;WKST=MO',
-            new \DateTime('2008-05-30')
+            new DateTime('2008-05-30')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2009-01-01'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2009-01-02'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2009-01-03'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2009-01-04'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2015-01-01'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2009-01-01'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2009-01-02'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2009-01-03'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2009-01-04'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2015-01-01'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerByYearDayTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerByYearDayTest.php
@@ -2,39 +2,40 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerByYearDayTest extends ArrayTransformerBase
 {
-    public function testByYearDay()
+    public function testByYearDay(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=4;BYYEARDAY=125',
-            new \DateTime('2013-01-02')
+            new DateTime('2013-01-02')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2013-05-05'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-05'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2015-05-05'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-05-04'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-05-05'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-05-05'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2015-05-05'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-05-04'), $computed[3]->getStart());
     }
 
-    public function testByYearDayNegative()
+    public function testByYearDayNegative(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=4;BYYEARDAY=-307',
-            new \DateTime('2013-06-07')
+            new DateTime('2013-06-07')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2015-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2017-02-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2015-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2017-02-28'), $computed[3]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerConstraintTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerConstraintTest.php
@@ -44,7 +44,7 @@ class ArrayTransformerConstraintTest extends ArrayTransformerBase
      */
     public function testBefore($dateTimeClassName, $frequency, $count, $start, $before, $inc, $expected)
     {
-        $rule = new Rule();
+        $rule = Rule::createFromArray($this->defaults);
         $rule
             ->setFreq($frequency)
             ->setCount($count)
@@ -96,7 +96,7 @@ class ArrayTransformerConstraintTest extends ArrayTransformerBase
      */
     public function testAfter($dateTimeClassName, $frequency, $count, $start, $after, $inc, $countConstraintFailures, $expected)
     {
-        $rule = new Rule();
+        $rule = Rule::createFromArray($this->defaults);
         $rule
             ->setFreq($frequency)
             ->setCount($count)
@@ -162,14 +162,16 @@ class ArrayTransformerConstraintTest extends ArrayTransformerBase
      */
     public function testBetween($dateTimeClassName, $frequency, $start, $after, $before, $inc, $expected)
     {
-        $rule = new Rule();
+        $rule = Rule::createFromArray($this->defaults);
         $rule
             ->setFreq($frequency)
             ->setStartDate(new $dateTimeClassName($start))
         ;
 
         $constraint = new BetweenConstraint(
-            new $dateTimeClassName($after), new $dateTimeClassName($before), $inc
+            new $dateTimeClassName($after),
+            new $dateTimeClassName($before),
+            $inc
         );
         $computed = $this->transformer->transform($rule, $constraint);
 

--- a/tests/Recurr/Test/Transformer/ArrayTransformerDtendTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerDtendTest.php
@@ -2,56 +2,57 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerDtendTest extends ArrayTransformerBase
 {
-    public function testDtend()
+    public function testDtend(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=3;DTEND=20140316T040000',
-            new \DateTime('2014-03-14 04:00:00')
+            new DateTime('2014-03-14 04:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(3, $computed);
-        $this->assertEquals(new \DateTime('2014-03-14 04:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-16 04:00:00'), $computed[0]->getEnd());
-        $this->assertEquals(new \DateTime('2014-04-14 04:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-16 04:00:00'), $computed[1]->getEnd());
-        $this->assertEquals(new \DateTime('2014-05-14 04:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-16 04:00:00'), $computed[2]->getEnd());
+        $this->assertEquals(new DateTime('2014-03-14 04:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-03-16 04:00:00'), $computed[0]->getEnd());
+        $this->assertEquals(new DateTime('2014-04-14 04:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-04-16 04:00:00'), $computed[1]->getEnd());
+        $this->assertEquals(new DateTime('2014-05-14 04:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-05-16 04:00:00'), $computed[2]->getEnd());
     }
 
-    public function testDtendWithoutLastDayOfMonthFix()
+    public function testDtendWithoutLastDayOfMonthFix(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;DTEND=20140201T040000',
-            new \DateTime('2014-01-31 04:00:00')
+            new DateTime('2014-01-31 04:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2014-01-31 04:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-01 04:00:00'), $computed[0]->getEnd());
-        $this->assertEquals(new \DateTime('2014-03-31 04:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-01 04:00:00'), $computed[1]->getEnd());
-        $this->assertEquals(new \DateTime('2014-05-31 04:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-01 04:00:00'), $computed[2]->getEnd());
-        $this->assertEquals(new \DateTime('2014-07-31 04:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-08-01 04:00:00'), $computed[3]->getEnd());
-        $this->assertEquals(new \DateTime('2014-08-31 04:00:00'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2014-09-01 04:00:00'), $computed[4]->getEnd());
+        $this->assertEquals(new DateTime('2014-01-31 04:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-01 04:00:00'), $computed[0]->getEnd());
+        $this->assertEquals(new DateTime('2014-03-31 04:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-04-01 04:00:00'), $computed[1]->getEnd());
+        $this->assertEquals(new DateTime('2014-05-31 04:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-06-01 04:00:00'), $computed[2]->getEnd());
+        $this->assertEquals(new DateTime('2014-07-31 04:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-08-01 04:00:00'), $computed[3]->getEnd());
+        $this->assertEquals(new DateTime('2014-08-31 04:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-09-01 04:00:00'), $computed[4]->getEnd());
     }
 
-    public function testDtendWithLastDayOfMonthFix()
+    public function testDtendWithLastDayOfMonthFix(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;DTEND=20140201T040000',
-            new \DateTime('2014-01-31 04:00:00')
+            new DateTime('2014-01-31 04:00:00')
         );
 
         $config = new ArrayTransformerConfig();
@@ -61,15 +62,15 @@ class ArrayTransformerDtendTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2014-01-31 04:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-01 04:00:00'), $computed[0]->getEnd());
-        $this->assertEquals(new \DateTime('2014-02-28 04:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-01 04:00:00'), $computed[1]->getEnd());
-        $this->assertEquals(new \DateTime('2014-03-31 04:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-01 04:00:00'), $computed[2]->getEnd());
-        $this->assertEquals(new \DateTime('2014-04-30 04:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-01 04:00:00'), $computed[3]->getEnd());
-        $this->assertEquals(new \DateTime('2014-05-31 04:00:00'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-01 04:00:00'), $computed[4]->getEnd());
+        $this->assertEquals(new DateTime('2014-01-31 04:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-01 04:00:00'), $computed[0]->getEnd());
+        $this->assertEquals(new DateTime('2014-02-28 04:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-01 04:00:00'), $computed[1]->getEnd());
+        $this->assertEquals(new DateTime('2014-03-31 04:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-01 04:00:00'), $computed[2]->getEnd());
+        $this->assertEquals(new DateTime('2014-04-30 04:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-05-01 04:00:00'), $computed[3]->getEnd());
+        $this->assertEquals(new DateTime('2014-05-31 04:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2014-06-01 04:00:00'), $computed[4]->getEnd());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerExDateTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerExDateTest.php
@@ -7,13 +7,12 @@ use Recurr\DateExclusion;
 
 class ArrayTransformerExDateTest extends ArrayTransformerBase
 {
-
     /**
      * Original timezone. Restore it upon test suite completion!
      *
      * @var string
      */
-    protected static $originalTimezoneName;
+    protected static string $originalTimezoneName;
 
     public static function setUpBeforeClass(): void
     {
@@ -30,7 +29,7 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         parent::tearDownAfterClass();
     }
 
-    public function testExDateNoTime()
+    public function testExDateNoTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3;EXDATE=20140602',
@@ -44,7 +43,7 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2014-06-03'), $computed[1]->getStart());
     }
 
-    public function testExDateWithTime()
+    public function testExDateWithTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3;EXDATE=20140603T040000',
@@ -58,7 +57,7 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2014-06-02 04:00:00'), $computed[1]->getStart());
     }
 
-    public function testExDateWithUtcTime()
+    public function testExDateWithUtcTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3;EXDATE=20140602T110000Z',
@@ -72,7 +71,7 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2014-06-03 07:00:00'), $computed[1]->getStart());
     }
 
-    public function testExDateWithMixedTimezones()
+    public function testExDateWithMixedTimezones(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3;EXDATE=20140601T040000,20140602T080000Z',
@@ -85,17 +84,14 @@ class ArrayTransformerExDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2014-06-03 04:00:00'), $computed[0]->getStart());
     }
 
-    public function testSetExDates()
+    public function testSetExDates(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3',
             new \DateTime('2014-06-01')
         );
 
-        $exDates = array(
-            new DateExclusion(new \DateTime('2014-06-02'), false),
-        );
-        $rule->setExDates($exDates);
+        $rule->setExDates([new DateExclusion(new \DateTime('2014-06-02'), false),]);
 
         $computed = $this->transformer->transform($rule);
 

--- a/tests/Recurr/Test/Transformer/ArrayTransformerHourlyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerHourlyTest.php
@@ -2,75 +2,76 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
-class ArrayTransformerHoursTest extends ArrayTransformerBase
+class ArrayTransformerHourlyTest extends ArrayTransformerBase
 {
-    public function testHourly()
+    public function testHourly(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;',
-            new \DateTime('2013-02-28 23:00:00')
+            new DateTime('2013-02-28 23:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-02-28 23:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 00:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 01:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 02:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 03:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28 23:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 00:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 01:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 02:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 03:00:00'), $computed[4]->getStart());
     }
 
-    public function testHourlyInterval()
+    public function testHourlyInterval(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;INTERVAL=9;',
-            new \DateTime('2013-02-28 23:00:00')
+            new DateTime('2013-02-28 23:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-02-28 23:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 08:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-01 17:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-02 02:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-03-02 11:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28 23:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 08:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-03-01 17:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-03-02 02:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-03-02 11:00:00'), $computed[4]->getStart());
     }
 
-    public function testHourlyLeapYear()
+    public function testHourlyLeapYear(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;',
-            new \DateTime('2016-02-28 23:00:00')
+            new DateTime('2016-02-28 23:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-28 23:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 00:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 01:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 02:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 03:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-28 23:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 00:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 01:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 02:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 03:00:00'), $computed[4]->getStart());
     }
 
-    public function testHourlyCrossingYears()
+    public function testHourlyCrossingYears(): void
     {
         $rule = new Rule(
             'FREQ=HOURLY;COUNT=5;',
-            new \DateTime('2013-12-31 22:00:00')
+            new DateTime('2013-12-31 22:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-12-31 22:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-12-31 23:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-01 00:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-01 01:00:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-01 02:00:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-12-31 22:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-12-31 23:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-01-01 00:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-01-01 01:00:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-01 02:00:00'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerMinutelyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerMinutelyTest.php
@@ -2,41 +2,42 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
-class ArrayTransformerMinutesTest extends ArrayTransformerBase
+class ArrayTransformerMinutelyTest extends ArrayTransformerBase
 {
-    public function testMinutely()
+    public function testMinutely(): void
     {
         $rule = new Rule(
             'FREQ=MINUTELY;COUNT=5;',
-            new \DateTime('2016-02-29 23:58:00')
+            new DateTime('2016-02-29 23:58:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:59:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01 00:00:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01 00:01:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01 00:02:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:59:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01 00:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01 00:01:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01 00:02:00'), $computed[4]->getStart());
     }
 
-    public function testMinutelyInterval()
+    public function testMinutelyInterval(): void
     {
         $rule = new Rule(
             'FREQ=MINUTELY;COUNT=5;INTERVAL=58;',
-            new \DateTime('2013-02-28 23:58:00')
+            new DateTime('2013-02-28 23:58:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-02-28 23:58:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-29 00:56:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-29 01:54:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-29 02:52:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-02-29 03:50:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-02-28 23:58:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-02-29 00:56:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-02-29 01:54:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-02-29 02:52:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-02-29 03:50:00'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerMonthlyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerMonthlyTest.php
@@ -2,188 +2,189 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerMonthlyTest extends ArrayTransformerBase
 {
-    public function testMonthly()
+    public function testMonthly(): void
     {
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-28'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-28'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-28'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-29'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-29'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-03-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-04-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-05-29'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-30'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-30'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-30'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-30'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-03-30'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-04-30'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-05-30'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-31'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-31'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-31'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-05-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-07-31'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-03-31'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-05-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-07-31'), $computed[3]->getStart());
     }
 
-    public function testMonthlyOnLeapYear()
+    public function testMonthlyOnLeapYear(): void
     {
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-28'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-28'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-28'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-29'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-29'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-29'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-30'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-30'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-30'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-30'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-05-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-03-30'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-04-30'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-05-30'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-31'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-31'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-31'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-05-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-07-31'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-03-31'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-05-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-07-31'), $computed[3]->getStart());
     }
 
-    public function testLastDayOfMonthFix()
-    {
-        $transformerConfig = new ArrayTransformerConfig();
-        $transformerConfig->enableLastDayOfMonthFix();
-        $this->transformer->setConfig($transformerConfig);
-
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-28'));
-        $computed = $this->transformer->transform($rule);
-        $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-28'), $computed[3]->getStart());
-
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-29'));
-        $computed = $this->transformer->transform($rule);
-        $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-29'), $computed[3]->getStart());
-
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-30'));
-        $computed = $this->transformer->transform($rule);
-        $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-30'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-30'), $computed[3]->getStart());
-
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-01-31'));
-        $computed = $this->transformer->transform($rule);
-        $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-03-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-04-30'), $computed[3]->getStart());
-    }
-
-    public function testLastDayOfMonthFixOnLeapYear()
+    public function testLastDayOfMonthFix(): void
     {
         $transformerConfig = new ArrayTransformerConfig();
         $transformerConfig->enableLastDayOfMonthFix();
         $this->transformer->setConfig($transformerConfig);
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-28'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-28'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-28'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-28'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-29'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-29'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-29'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-30'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-30'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-30'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-30'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-30'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-30'), $computed[3]->getStart());
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2016-01-31'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-01-31'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2016-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-03-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-04-30'), $computed[3]->getStart());
     }
 
-    public function testLastDayOfMonthFixOn29thDayIn30DayMonth()
+    public function testLastDayOfMonthFixOnLeapYear(): void
     {
         $transformerConfig = new ArrayTransformerConfig();
         $transformerConfig->enableLastDayOfMonthFix();
         $this->transformer->setConfig($transformerConfig);
 
-        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new \DateTime('2014-08-29'));
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-28'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2014-08-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-09-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-10-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-11-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-01-28'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-28'), $computed[3]->getStart());
+
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-29'));
+        $computed = $this->transformer->transform($rule);
+        $this->assertCount(4, $computed);
+        $this->assertEquals(new DateTime('2016-01-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-29'), $computed[3]->getStart());
+
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-30'));
+        $computed = $this->transformer->transform($rule);
+        $this->assertCount(4, $computed);
+        $this->assertEquals(new DateTime('2016-01-30'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-30'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-30'), $computed[3]->getStart());
+
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2016-01-31'));
+        $computed = $this->transformer->transform($rule);
+        $this->assertCount(4, $computed);
+        $this->assertEquals(new DateTime('2016-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-30'), $computed[3]->getStart());
     }
 
-    public function testLastDayOfMonth()
+    public function testLastDayOfMonthFixOn29thDayIn30DayMonth(): void
+    {
+        $transformerConfig = new ArrayTransformerConfig();
+        $transformerConfig->enableLastDayOfMonthFix();
+        $this->transformer->setConfig($transformerConfig);
+
+        $rule     = new Rule('FREQ=MONTHLY;COUNT=4;INTERVAL=1', new DateTime('2014-08-29'));
+        $computed = $this->transformer->transform($rule);
+        $this->assertCount(4, $computed);
+        $this->assertEquals(new DateTime('2014-08-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-09-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-10-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-11-29'), $computed[3]->getStart());
+    }
+
+    public function testLastDayOfMonth(): void
     {
         $rule = new Rule(
             'FREQ=MONTHLY;COUNT=5;BYMONTHDAY=28,29,30,31;BYSETPOS=-1',
-            new \DateTime('2016-01-29')
+            new DateTime('2016-01-29')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-01-31'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-31'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-04-30'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-05-31'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-01-31'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-31'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-04-30'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-05-31'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerRDateTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerRDateTest.php
@@ -7,13 +7,12 @@ use Recurr\DateInclusion;
 
 class ArrayTransformerRDateTest extends ArrayTransformerBase
 {
-
     /**
      * Original timezone. Restore it upon test suite completion!
      *
      * @var string
      */
-    protected static $originalTimezoneName;
+    protected static string $originalTimezoneName;
 
     public static function setUpBeforeClass(): void
     {
@@ -30,7 +29,7 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         parent::tearDownAfterClass();
     }
 
-    public function testRDateInConjunctionWithExDate()
+    public function testRDateInConjunctionWithExDate(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=3;RDATE=20151208;EXDATE=20151208',
@@ -45,7 +44,7 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-12-12'), $computed[2]->getStart());
     }
 
-    public function testRDateNoTime()
+    public function testRDateNoTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=2;RDATE=20151208',
@@ -60,7 +59,7 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-12-08'), $computed[2]->getStart());
     }
 
-    public function testRDateWithTime()
+    public function testRDateWithTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=2;RDATE=20151208T010000',
@@ -75,7 +74,7 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-12-08 01:00:00'), $computed[2]->getStart());
     }
 
-    public function testRDateWithUtcTime()
+    public function testRDateWithUtcTime(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=2;RDATE=20151208T110000Z',
@@ -90,7 +89,7 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-12-08 11:00:00Z'), $computed[2]->getStart());
     }
 
-    public function testRDateWithMixedTimezones()
+    public function testRDateWithMixedTimezones(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=2;RDATE=20151208T190000,20151125T080000Z',
@@ -106,17 +105,14 @@ class ArrayTransformerRDateTest extends ArrayTransformerBase
         $this->assertEquals(new \DateTime('2015-11-25 08:00:00Z'), $computed[3]->getStart());
     }
 
-    public function testSetRDates()
+    public function testSetRDates(): void
     {
         $rule = new Rule(
             'FREQ=DAILY;COUNT=2',
             new \DateTime('2015-12-10')
         );
 
-        $rDates = array(
-            new DateInclusion(new \DateTime('2015-12-08'), false),
-        );
-        $rule->setRDates($rDates);
+        $rule->setRDates([new DateInclusion(new \DateTime('2015-12-08'), false),]);
 
         $computed = $this->transformer->transform($rule);
 

--- a/tests/Recurr/Test/Transformer/ArrayTransformerSecondlyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerSecondlyTest.php
@@ -2,41 +2,42 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 
 class ArrayTransformerSecondlyTest extends ArrayTransformerBase
 {
-    public function testSecondly()
+    public function testSecondly(): void
     {
         $rule = new Rule(
             'FREQ=SECONDLY;COUNT=5;',
-            new \DateTime('2016-02-29 23:58:00')
+            new DateTime('2016-02-29 23:58:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:01'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:02'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:03'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:04'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:01'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:02'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:03'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:04'), $computed[4]->getStart());
     }
 
-    public function testSecondlyInterval()
+    public function testSecondlyInterval(): void
     {
         $rule = new Rule(
             'FREQ=SECONDLY;COUNT=5;INTERVAL=58;',
-            new \DateTime('2016-02-29 23:58:00')
+            new DateTime('2016-02-29 23:58:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:58:58'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 23:59:56'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01 00:00:54'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-01 00:01:52'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:58:58'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 23:59:56'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01 00:00:54'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-03-01 00:01:52'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerTest.php
@@ -2,16 +2,17 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerTest extends ArrayTransformerBase
 {
-    public function testVirtualLimitWithCountLimit()
+    public function testVirtualLimitWithCountLimit(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=30',
-            new \DateTime('2014-03-16 04:00:00')
+            new DateTime('2014-03-16 04:00:00')
         );
 
         $config = new ArrayTransformerConfig();
@@ -26,11 +27,11 @@ class ArrayTransformerTest extends ArrayTransformerBase
         $this->assertCount(30, $computed);
     }
 
-    public function testVirtualLimitWithoutCountLimit()
+    public function testVirtualLimitWithoutCountLimit(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY',
-            new \DateTime('2014-03-16 04:00:00')
+            new DateTime('2014-03-16 04:00:00')
         );
 
         $config = new ArrayTransformerConfig();
@@ -45,68 +46,68 @@ class ArrayTransformerTest extends ArrayTransformerBase
         $this->assertCount(10, $computed);
     }
 
-    public function testUntil()
+    public function testUntil(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;UNTIL=20160316T040000',
-            new \DateTime('2014-03-16 04:00:00')
+            new DateTime('2014-03-16 04:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(3, $computed);
-        $this->assertEquals(new \DateTime('2014-03-16 04:00:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2015-03-16 04:00:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-16 04:00:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-03-16 04:00:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2015-03-16 04:00:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-03-16 04:00:00'), $computed[2]->getStart());
     }
 
-    public function testRfc2445Example()
+    public function testRfc2445Example(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;INTERVAL=2;BYMONTH=1;BYDAY=SU;BYHOUR=8,9;COUNT=30',
-            new \DateTime('1997-01-05 08:30:00')
+            new DateTime('1997-01-05 08:30:00')
         );
 
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(30, $computed);
-        $this->assertEquals(new \DateTime('1997-01-05 08:30:00'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-05 09:30:00'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-12 08:30:00'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-12 09:30:00'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-19 08:30:00'), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-19 09:30:00'), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-26 08:30:00'), $computed[6]->getStart());
-        $this->assertEquals(new \DateTime('1997-01-26 09:30:00'), $computed[7]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-03 08:30:00'), $computed[8]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-03 09:30:00'), $computed[9]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-10 08:30:00'), $computed[10]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-10 09:30:00'), $computed[11]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-17 08:30:00'), $computed[12]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-17 09:30:00'), $computed[13]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-24 08:30:00'), $computed[14]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-24 09:30:00'), $computed[15]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-31 08:30:00'), $computed[16]->getStart());
-        $this->assertEquals(new \DateTime('1999-01-31 09:30:00'), $computed[17]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-07 08:30:00'), $computed[18]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-07 09:30:00'), $computed[19]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-14 08:30:00'), $computed[20]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-14 09:30:00'), $computed[21]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-21 08:30:00'), $computed[22]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-21 09:30:00'), $computed[23]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-28 08:30:00'), $computed[24]->getStart());
-        $this->assertEquals(new \DateTime('2001-01-28 09:30:00'), $computed[25]->getStart());
-        $this->assertEquals(new \DateTime('2003-01-05 08:30:00'), $computed[26]->getStart());
-        $this->assertEquals(new \DateTime('2003-01-05 09:30:00'), $computed[27]->getStart());
-        $this->assertEquals(new \DateTime('2003-01-12 08:30:00'), $computed[28]->getStart());
-        $this->assertEquals(new \DateTime('2003-01-12 09:30:00'), $computed[29]->getStart());
+        $this->assertEquals(new DateTime('1997-01-05 08:30:00'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('1997-01-05 09:30:00'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('1997-01-12 08:30:00'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('1997-01-12 09:30:00'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('1997-01-19 08:30:00'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('1997-01-19 09:30:00'), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('1997-01-26 08:30:00'), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('1997-01-26 09:30:00'), $computed[7]->getStart());
+        $this->assertEquals(new DateTime('1999-01-03 08:30:00'), $computed[8]->getStart());
+        $this->assertEquals(new DateTime('1999-01-03 09:30:00'), $computed[9]->getStart());
+        $this->assertEquals(new DateTime('1999-01-10 08:30:00'), $computed[10]->getStart());
+        $this->assertEquals(new DateTime('1999-01-10 09:30:00'), $computed[11]->getStart());
+        $this->assertEquals(new DateTime('1999-01-17 08:30:00'), $computed[12]->getStart());
+        $this->assertEquals(new DateTime('1999-01-17 09:30:00'), $computed[13]->getStart());
+        $this->assertEquals(new DateTime('1999-01-24 08:30:00'), $computed[14]->getStart());
+        $this->assertEquals(new DateTime('1999-01-24 09:30:00'), $computed[15]->getStart());
+        $this->assertEquals(new DateTime('1999-01-31 08:30:00'), $computed[16]->getStart());
+        $this->assertEquals(new DateTime('1999-01-31 09:30:00'), $computed[17]->getStart());
+        $this->assertEquals(new DateTime('2001-01-07 08:30:00'), $computed[18]->getStart());
+        $this->assertEquals(new DateTime('2001-01-07 09:30:00'), $computed[19]->getStart());
+        $this->assertEquals(new DateTime('2001-01-14 08:30:00'), $computed[20]->getStart());
+        $this->assertEquals(new DateTime('2001-01-14 09:30:00'), $computed[21]->getStart());
+        $this->assertEquals(new DateTime('2001-01-21 08:30:00'), $computed[22]->getStart());
+        $this->assertEquals(new DateTime('2001-01-21 09:30:00'), $computed[23]->getStart());
+        $this->assertEquals(new DateTime('2001-01-28 08:30:00'), $computed[24]->getStart());
+        $this->assertEquals(new DateTime('2001-01-28 09:30:00'), $computed[25]->getStart());
+        $this->assertEquals(new DateTime('2003-01-05 08:30:00'), $computed[26]->getStart());
+        $this->assertEquals(new DateTime('2003-01-05 09:30:00'), $computed[27]->getStart());
+        $this->assertEquals(new DateTime('2003-01-12 08:30:00'), $computed[28]->getStart());
+        $this->assertEquals(new DateTime('2003-01-12 09:30:00'), $computed[29]->getStart());
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $rule = new Rule(
             'FREQ=YEARLY;COUNT=10',
-            new \DateTime('2000-01-01 09:00:00')
+            new DateTime('2000-01-01 09:00:00')
         );
 
         $computed = $this->transformer->transform($rule);
@@ -116,14 +117,14 @@ class ArrayTransformerTest extends ArrayTransformerBase
         $this->assertEquals(10, $computed[9]->getIndex());
     }
 
-    public function testOccurrenceBySetPosOnJanuaryFirst()
+    public function testOccurrenceBySetPosOnJanuaryFirst(): void
     {
-        $rule = new Rule('FREQ=MONTHLY;COUNT=4;BYSETPOS=1', new \DateTime('2018-11-01'));
+        $rule = new Rule('FREQ=MONTHLY;COUNT=4;BYSETPOS=1', new DateTime('2018-11-01'));
         $computed = $this->transformer->transform($rule);
         $this->assertCount(4, $computed);
-        $this->assertEquals(new \DateTime('2018-11-01'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2018-12-01'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2019-01-01'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2019-02-01'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2018-11-01'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2018-12-01'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2019-01-01'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2019-02-01'), $computed[3]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerWeeklyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerWeeklyTest.php
@@ -2,18 +2,20 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
+use DateTimeZone;
 use Recurr\Rule;
 
 class ArrayTransformerWeeklyTest extends ArrayTransformerBase
 {
-    public function testWeekly()
+    public function testWeekly(): void
     {
         $timezone = 'America/New_York';
-        $timezoneObj = new \DateTimeZone($timezone);
+        $timezoneObj = new DateTimeZone($timezone);
 
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;INTERVAL=1',
-            new \DateTime('2013-06-13 00:00:00', $timezoneObj),
+            new DateTime('2013-06-13 00:00:00', $timezoneObj),
             null,
             $timezone
         );
@@ -21,21 +23,21 @@ class ArrayTransformerWeeklyTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-06-13 00:00:00', $timezoneObj), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-20 00:00:00', $timezoneObj), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2013-06-27 00:00:00', $timezoneObj), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-04 00:00:00', $timezoneObj), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2013-07-11 00:00:00', $timezoneObj), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13 00:00:00', $timezoneObj), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2013-06-20 00:00:00', $timezoneObj), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2013-06-27 00:00:00', $timezoneObj), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-07-04 00:00:00', $timezoneObj), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2013-07-11 00:00:00', $timezoneObj), $computed[4]->getStart());
     }
 
-    public function testWeeklyInterval()
+    public function testWeeklyInterval(): void
     {
         $timezone = 'America/New_York';
-        $timezoneObj = new \DateTimeZone($timezone);
+        $timezoneObj = new DateTimeZone($timezone);
 
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=5;INTERVAL=2',
-            new \DateTime('2013-12-19 00:00:00', $timezoneObj),
+            new DateTime('2013-12-19 00:00:00', $timezoneObj),
             null,
             $timezone
         );
@@ -43,21 +45,21 @@ class ArrayTransformerWeeklyTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2013-12-19 00:00:00', $timezoneObj), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-02 00:00:00', $timezoneObj), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-16 00:00:00', $timezoneObj), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-30 00:00:00', $timezoneObj), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2014-02-13 00:00:00', $timezoneObj), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2013-12-19 00:00:00', $timezoneObj), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-01-02 00:00:00', $timezoneObj), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-01-16 00:00:00', $timezoneObj), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2014-01-30 00:00:00', $timezoneObj), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2014-02-13 00:00:00', $timezoneObj), $computed[4]->getStart());
     }
 
-    public function testWeeklyIntervalLeapYear()
+    public function testWeeklyIntervalLeapYear(): void
     {
         $timezone = 'America/New_York';
-        $timezoneObj = new \DateTimeZone($timezone);
+        $timezoneObj = new DateTimeZone($timezone);
 
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=7;INTERVAL=2',
-            new \DateTime('2015-12-21 00:00:00', $timezoneObj),
+            new DateTime('2015-12-21 00:00:00', $timezoneObj),
             null,
             $timezone
         );
@@ -65,23 +67,23 @@ class ArrayTransformerWeeklyTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(7, $computed);
-        $this->assertEquals(new \DateTime('2015-12-21 00:00:00', $timezoneObj), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2016-01-04 00:00:00', $timezoneObj), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2016-01-18 00:00:00', $timezoneObj), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-01 00:00:00', $timezoneObj), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-15 00:00:00', $timezoneObj), $computed[4]->getStart());
-        $this->assertEquals(new \DateTime('2016-02-29 00:00:00', $timezoneObj), $computed[5]->getStart());
-        $this->assertEquals(new \DateTime('2016-03-14 00:00:00', $timezoneObj), $computed[6]->getStart());
+        $this->assertEquals(new DateTime('2015-12-21 00:00:00', $timezoneObj), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2016-01-04 00:00:00', $timezoneObj), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2016-01-18 00:00:00', $timezoneObj), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2016-02-01 00:00:00', $timezoneObj), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2016-02-15 00:00:00', $timezoneObj), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29 00:00:00', $timezoneObj), $computed[5]->getStart());
+        $this->assertEquals(new DateTime('2016-03-14 00:00:00', $timezoneObj), $computed[6]->getStart());
     }
 
-    public function testWeeklyIntervalTouchingJan1()
+    public function testWeeklyIntervalTouchingJan1(): void
     {
         $timezone = 'America/New_York';
-        $timezoneObj = new \DateTimeZone($timezone);
+        $timezoneObj = new DateTimeZone($timezone);
 
         $rule = new Rule(
             'FREQ=WEEKLY;COUNT=3;INTERVAL=2',
-            new \DateTime('2013-12-18 00:00:00', $timezoneObj),
+            new DateTime('2013-12-18 00:00:00', $timezoneObj),
             null,
             $timezone
         );
@@ -89,8 +91,8 @@ class ArrayTransformerWeeklyTest extends ArrayTransformerBase
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(3, $computed);
-        $this->assertEquals(new \DateTime('2013-12-18 00:00:00', $timezoneObj), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-01 00:00:00', $timezoneObj), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2014-01-15 00:00:00', $timezoneObj), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-12-18 00:00:00', $timezoneObj), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-01-01 00:00:00', $timezoneObj), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2014-01-15 00:00:00', $timezoneObj), $computed[2]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/ArrayTransformerYearlyTest.php
+++ b/tests/Recurr/Test/Transformer/ArrayTransformerYearlyTest.php
@@ -2,57 +2,58 @@
 
 namespace Recurr\Test\Transformer;
 
+use DateTime;
 use Recurr\Rule;
 use Recurr\Transformer\ArrayTransformerConfig;
 
 class ArrayTransformerYearlyTest extends ArrayTransformerBase
 {
-    public function testYearly()
+    public function testYearly(): void
     {
-        $rule = new Rule('FREQ=YEARLY;COUNT=3;INTERVAL=1', new \DateTime('2013-06-13 00:00:00'));
+        $rule = new Rule('FREQ=YEARLY;COUNT=3;INTERVAL=1', new DateTime('2013-06-13 00:00:00'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(3, $computed);
-        $this->assertEquals(new \DateTime('2013-06-13'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2014-06-13'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2015-06-13'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2013-06-13'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2014-06-13'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2015-06-13'), $computed[2]->getStart());
     }
 
-    public function testYearlyByMonth()
+    public function testYearlyByMonth(): void
     {
-        $rule = new Rule('FREQ=YEARLY;BYMONTH=9;COUNT=3', new \DateTime('2017-07-31 00:00:00'));
+        $rule = new Rule('FREQ=YEARLY;BYMONTH=9;COUNT=3', new DateTime('2017-07-31 00:00:00'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(0, $computed);
     }
 
-    public function testLeapYear()
+    public function testLeapYear(): void
     {
-        $rule     = new Rule('FREQ=YEARLY;COUNT=5;INTERVAL=1', new \DateTime('2096-02-29'));
+        $rule     = new Rule('FREQ=YEARLY;COUNT=5;INTERVAL=1', new DateTime('2096-02-29'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2096-02-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2104-02-29'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2108-02-29'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2112-02-29'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2116-02-29'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2096-02-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2104-02-29'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2108-02-29'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2112-02-29'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2116-02-29'), $computed[4]->getStart());
     }
 
-    public function testLastDayOfMonthFixLeapYear()
+    public function testLastDayOfMonthFixLeapYear(): void
     {
         $transformerConfig = new ArrayTransformerConfig();
         $transformerConfig->enableLastDayOfMonthFix();
         $this->transformer->setConfig($transformerConfig);
 
-        $rule     = new Rule('FREQ=YEARLY;COUNT=5;INTERVAL=1', new \DateTime('2016-02-29'));
+        $rule     = new Rule('FREQ=YEARLY;COUNT=5;INTERVAL=1', new DateTime('2016-02-29'));
         $computed = $this->transformer->transform($rule);
 
         $this->assertCount(5, $computed);
-        $this->assertEquals(new \DateTime('2016-02-29'), $computed[0]->getStart());
-        $this->assertEquals(new \DateTime('2017-02-28'), $computed[1]->getStart());
-        $this->assertEquals(new \DateTime('2018-02-28'), $computed[2]->getStart());
-        $this->assertEquals(new \DateTime('2019-02-28'), $computed[3]->getStart());
-        $this->assertEquals(new \DateTime('2020-02-29'), $computed[4]->getStart());
+        $this->assertEquals(new DateTime('2016-02-29'), $computed[0]->getStart());
+        $this->assertEquals(new DateTime('2017-02-28'), $computed[1]->getStart());
+        $this->assertEquals(new DateTime('2018-02-28'), $computed[2]->getStart());
+        $this->assertEquals(new DateTime('2019-02-28'), $computed[3]->getStart());
+        $this->assertEquals(new DateTime('2020-02-29'), $computed[4]->getStart());
     }
 }

--- a/tests/Recurr/Test/Transformer/Constraint/AfterConstraintTest.php
+++ b/tests/Recurr/Test/Transformer/Constraint/AfterConstraintTest.php
@@ -1,27 +1,29 @@
 <?php
 
-namespace Recurr\Test\Transformer\Filter;
+namespace Recurr\Test\Transformer\Constraint;
 
+use DateTime;
+use PHPUnit\Framework\TestCase;
 use Recurr\Transformer\Constraint\AfterConstraint;
 
-class AfterConstraintTest extends \PHPUnit\Framework\TestCase
+class AfterConstraintTest extends TestCase
 {
-    public function testAfter()
+    public function testAfter(): void
     {
-        $after = new \DateTime('2014-06-17');
+        $after = new DateTime('2014-06-17');
 
         $constraint = new AfterConstraint($after, false);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertFalse($testResult);
     }
 
-    public function testAfterInc()
+    public function testAfterInc(): void
     {
-        $after = new \DateTime('2014-06-17');
+        $after = new DateTime('2014-06-17');
 
         $constraint = new AfterConstraint($after, true);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertTrue($testResult);
     }

--- a/tests/Recurr/Test/Transformer/Constraint/BeforeConstraintTest.php
+++ b/tests/Recurr/Test/Transformer/Constraint/BeforeConstraintTest.php
@@ -1,27 +1,29 @@
 <?php
 
-namespace Recurr\Test\Transformer\Filter;
+namespace Recurr\Test\Transformer\Constraint;
 
+use DateTime;
+use PHPUnit\Framework\TestCase;
 use Recurr\Transformer\Constraint\BeforeConstraint;
 
-class BeforeConstraintTest extends \PHPUnit\Framework\TestCase
+class BeforeConstraintTest extends TestCase
 {
-    public function testBefore()
+    public function testBefore(): void
     {
-        $before = new \DateTime('2014-06-17');
+        $before = new DateTime('2014-06-17');
 
         $constraint = new BeforeConstraint($before, false);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertFalse($testResult);
     }
 
-    public function testBeforeInc()
+    public function testBeforeInc(): void
     {
-        $before = new \DateTime('2014-06-17');
+        $before = new DateTime('2014-06-17');
 
         $constraint = new BeforeConstraint($before, true);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertTrue($testResult);
     }

--- a/tests/Recurr/Test/Transformer/Constraint/BetweenConstraintTest.php
+++ b/tests/Recurr/Test/Transformer/Constraint/BetweenConstraintTest.php
@@ -1,29 +1,31 @@
 <?php
 
-namespace Recurr\Test\Transformer\Filter;
+namespace Recurr\Test\Transformer\Constraint;
 
+use DateTime;
+use PHPUnit\Framework\TestCase;
 use Recurr\Transformer\Constraint\BetweenConstraint;
 
-class BetweenConstraintTest extends \PHPUnit\Framework\TestCase
+class BetweenConstraintTest extends TestCase
 {
-    public function testBetween()
+    public function testBetween(): void
     {
-        $after  = new \DateTime('2014-06-10');
-        $before = new \DateTime('2014-06-17');
+        $after  = new DateTime('2014-06-10');
+        $before = new DateTime('2014-06-17');
 
         $constraint = new BetweenConstraint($after, $before, false);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertFalse($testResult);
     }
 
-    public function testBetweenInc()
+    public function testBetweenInc(): void
     {
-        $after  = new \DateTime('2014-06-10');
-        $before = new \DateTime('2014-06-17');
+        $after  = new DateTime('2014-06-10');
+        $before = new DateTime('2014-06-17');
 
         $constraint = new BetweenConstraint($after, $before, true);
-        $testResult = $constraint->test(new \DateTime('2014-06-17'));
+        $testResult = $constraint->test(new DateTime('2014-06-17'));
 
         $this->assertTrue($testResult);
     }

--- a/tests/Recurr/Test/Transformer/TextTransformerTest.php
+++ b/tests/Recurr/Test/Transformer/TextTransformerTest.php
@@ -9,7 +9,7 @@ use Recurr\Transformer\TextTransformer;
 
 class TextTransformerTest extends \PHPUnit\Framework\TestCase
 {
-    private static $languages = array();
+    private static $languages = [];
 
     /**
      * @dataProvider generateTests
@@ -26,279 +26,279 @@ class TextTransformerTest extends \PHPUnit\Framework\TestCase
 
     public static function generateTests()
     {
-        $baseTests = array(
+        $baseTests = [
             // Count
-            array(
+            [
                 'FREQ=YEARLY;COUNT=1',
                 'yearly on March 16 for 1 time',
-            ),
+            ],
             // CountPlural
-            array(
+            [
                 'FREQ=YEARLY;COUNT=3',
                 'yearly on March 16 for 3 times',
-            ),
+            ],
             // Until
-            array(
+            [
                 'FREQ=YEARLY;UNTIL=20140704T040000Z',
                 'yearly on March 16 until July 4, 2014',
-            ),
+            ],
             // FullyConvertible
-            array(
+            [
                 'FREQ=YEARLY;BYHOUR=1',
                 'yearly on March 16 (~ approximate)',
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYMINUTE=1',
                 'yearly on March 16 (~ approximate)',
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYSECOND=1',
                 'yearly on March 16 (~ approximate)',
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYWEEKNO=50',
                 'monthly (~ approximate)',
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYYEARDAY=200',
                 'monthly (~ approximate)',
-            ),
+            ],
 
             // Monthly
-            array(
+            [
                 'FREQ=MONTHLY',
                 'monthly',
-            ),
+            ],
             // MonthlyPlural
-            array(
+            [
                 'FREQ=MONTHLY;INTERVAL=10',
                 'every 10 months',
-            ),
+            ],
             // MonthlyByMonth
-            array(
+            [
                 'FREQ=MONTHLY;BYMONTH=1,8,5',
                 'every January, May and August'
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;INTERVAL=2;BYMONTH=1,8,5',
                 'every 2 months in January, May and August',
-            ),
+            ],
             // MonthlyByMonthDay
-            array(
+            [
                 'FREQ=MONTHLY;BYMONTHDAY=5,1,21',
                 'monthly on the 1st, 5th and 21st'
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
                 'monthly on Tuesday or Friday the 1st, 5th or 21st',
-            ),
+            ],
             // MonthlyByNegativeMonthDay
-            array(
+            [
                 'FREQ=MONTHLY;BYMONTHDAY=-1,21',
                 'monthly on the 21st day and on the last day'
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYMONTHDAY=-2,1;BYDAY=TU,FR',
                 'monthly on Tuesday or Friday the 1st day or 2nd to the last day',
-            ),
+            ],
             // MonthlyByDay
-            array(
+            [
                 'FREQ=MONTHLY;BYDAY=TU,WE,FR',
                 'monthly on Tuesday, Wednesday and Friday'
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYDAY=+4MO',
                 'monthly on the 4th Monday',
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYDAY=+4MO,+2TU',
                 'monthly on the 4th Monday and 2nd Tuesday',
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYDAY=+4MO,+2TU,+3WE',
                 'monthly on the 4th Monday, 2nd Tuesday and 3rd Wednesday',
-            ),
-            array(
+            ],
+            [
                 'FREQ=MONTHLY;BYDAY=1MO,+1TU,+2WE,+3WE,+4WE,-1TH,-2FR,-3SA,-4SU',
                 'monthly on the 1st Monday, 1st Tuesday, 2nd Wednesday, 3rd Wednesday, 4th Wednesday, last Thursday, 2nd to the last Friday, 3rd to the last Saturday and 4th to the last Sunday',
-            ),
+            ],
 
             // Daily
-            array(
+            [
                 'FREQ=DAILY',
                 'daily',
-            ),
+            ],
             // DailyPlural
-            array(
+            [
                 'FREQ=DAILY;INTERVAL=10',
                 'every 10 days',
-            ),
+            ],
             // DailyByMonth
-            array(
+            [
                 'FREQ=DAILY;BYMONTH=1,8,5',
                 'daily in January, May and August',
-            ),
-            array(
+            ],
+            [
                 'FREQ=DAILY;INTERVAL=2;BYMONTH=1,8,5',
                 'every 2 days in January, May and August',
-            ),
+            ],
             // DailyByMonthDay
-            array(
+            [
                 'FREQ=DAILY;BYMONTHDAY=5,1,21',
                 'daily on the 1st, 5th and 21st of the month'
-            ),
-            array(
+            ],
+            [
                 'FREQ=DAILY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
                 'daily on Tuesday or Friday the 1st, 5th or 21st of the month',
-            ),
+            ],
             // DailyByDay
-            array(
+            [
                 'FREQ=DAILY;BYDAY=TU,WE,FR',
                 'daily on Tuesday, Wednesday and Friday',
-            ),
+            ],
 
             // Yearly
-            array(
+            [
                 'FREQ=YEARLY',
                 'yearly on March 16',
-            ),
+            ],
             // YearlyPlural
-            array(
+            [
                 'FREQ=YEARLY;INTERVAL=10',
                 'every 10 years on March 16',
-            ),
+            ],
             // YearlyByMonth
-            array(
+            [
                 'FREQ=YEARLY;BYMONTH=1,8,5',
                 'every January, May and August',
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;INTERVAL=2;BYMONTH=1,8,5',
                 'every 2 years in January, May and August',
-            ),
+            ],
             // ComplexYearly (first Tuesday that comes after a Monday in November, every 4years)
-            array(
+            [
                 'FREQ=YEARLY;INTERVAL=4;BYMONTH=11;BYDAY=TU;BYMONTHDAY=2,3,4,5,6,7,8',
                 'every 4 years in November on Tuesday the 2nd, 3rd, 4th, 5th, 6th, 7th or 8th of the month',
-            ),
+            ],
             // YearlyByMonthDay
-            array(
+            [
                 'FREQ=YEARLY;BYMONTHDAY=5,1,21',
                 'yearly on the 1st, 5th and 21st of the month',
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
                 'yearly on Tuesday or Friday the 1st, 5th or 21st of the month',
-            ),
+            ],
             // YearlyByDay
-            array(
+            [
                 'FREQ=YEARLY;BYDAY=TU,WE,FR',
                 'yearly on Tuesday, Wednesday and Friday',
-            ),
+            ],
             // YearlyByYearDay
-            array(
+            [
                 'FREQ=YEARLY;BYYEARDAY=1,200',
                 'yearly on the 1st and 200th day',
-            ),
+            ],
             // YearlyByWeekNumber
-            array(
+            [
                 'FREQ=YEARLY;BYWEEKNO=3',
                 'yearly in week 3 on Sunday'
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYWEEKNO=3,30,20',
                 'yearly in weeks 3, 20 and 30 on Sunday',
-            ),
+            ],
 
             // Weekly
-            array(
+            [
                 'FREQ=WEEKLY',
                 'weekly on Sunday',
-            ),
+            ],
             // WeeklyPlural
-            array(
+            [
                 'FREQ=WEEKLY;INTERVAL=10',
                 'every 10 weeks on Sunday',
-            ),
+            ],
             // WeeklyByMonth
-            array(
+            [
                 'FREQ=WEEKLY;BYMONTH=1,8,5',
                 'weekly on Sunday in January, May and August'
-            ),
-            array(
+            ],
+            [
                 'FREQ=WEEKLY;INTERVAL=2;BYMONTH=1,8,5',
                 'every 2 weeks on Sunday in January, May and August',
-            ),
+            ],
             // WeeklyByMonthDay
-            array(
+            [
                 'FREQ=WEEKLY;BYMONTHDAY=5,1,21',
                 'weekly on the 1st, 5th and 21st of the month'
-            ),
-            array(
+            ],
+            [
                 'FREQ=WEEKLY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
                 'weekly on Tuesday or Friday the 1st, 5th or 21st of the month',
-            ),
+            ],
             // WeeklyByDay
-            array(
+            [
                 'FREQ=WEEKLY;BYDAY=TU,WE,FR',
                 'weekly on Tuesday, Wednesday and Friday',
-            ),
+            ],
 
             // Check that start date impacts wording for yearly
-            array(
+            [
                 'FREQ=YEARLY;BYMONTH=3',
                 'yearly on March 16'
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;INTERVAL=2;BYMONTH=3',
                 'every 2 years on March 16'
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYMONTH=3;COUNT=5',
                 'yearly on March 16 for 5 times'
-            ),
-            array(
+            ],
+            [
                 'FREQ=YEARLY;BYMONTH=3;UNTIL=20121231T235959Z',
                 'yearly on March 16 until December 31, 2012'
-            ),
+            ],
 
             // Hourly
-            array(
+            [
                 'FREQ=HOURLY',
                 'hourly',
-            ),
+            ],
             // HourlyPlural
-            array(
+            [
                 'FREQ=HOURLY;INTERVAL=10',
                 'every 10 hours',
-            ),
+            ],
             // HourlyByMonth
-            array(
+            [
                 'FREQ=HOURLY;BYMONTH=1,8,5',
                 'hourly in January, May and August',
-            ),
-            array(
+            ],
+            [
                 'FREQ=HOURLY;INTERVAL=2;BYMONTH=1,8,5',
                 'every 2 hours in January, May and August',
-            ),
+            ],
             // HourlyByMonthDay
-            array(
+            [
                 'FREQ=HOURLY;BYMONTHDAY=5,1,21',
                 'hourly on the 1st, 5th and 21st of the month'
-            ),
-            array(
+            ],
+            [
                 'FREQ=HOURLY;BYMONTHDAY=5,1,21;BYDAY=TU,FR',
                 'hourly on Tuesday or Friday the 1st, 5th or 21st of the month',
-            ),
+            ],
             // HourlyByDay
-            array(
+            [
                 'FREQ=HOURLY;BYDAY=TU,WE,FR',
                 'hourly on Tuesday, Wednesday and Friday',
-            ),
-        );
+            ],
+        ];
 
-        $tests = array();
-        foreach (glob(__DIR__.'/Translations/*.yml') as $file) {
+        $tests = [];
+        foreach (glob(__DIR__ . '/Translations/*.yml') as $file) {
             $lang = basename($file, '.yml');
             self::$languages[$lang] = Yaml::parse(file_get_contents($file));
             $tests = array_merge($tests, array_map(function ($test) use ($lang) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->add('Recurr\\Test', __DIR__);

--- a/translations/da.php
+++ b/translations/da.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'søndag',
     'mandag',
     'tirsdag',
@@ -9,8 +9,8 @@ $days = array(
     'torsdag',
     'fredag',
     'lørdag',
-);
-$months = array(
+];
+$months = [
     'januar',
     'februar',
     'marts',
@@ -23,9 +23,9 @@ $months = array(
     'oktober',
     'november',
     'december',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Kunne ikke konvertere denne regel til tekst.',
     'for %count% times' => '%count% gange',
     'for one time' => 'en gang',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array(':e', ':a', ':a', ':e', ':e', ':e', ':e', ':e', ':e', ':e');
+        $ends = [':e', ':a', ':a', ':e', ':e', ':e', ':e', ':e', ':e', ':e'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/de.php
+++ b/translations/de.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'Sonntag',
     'Montag',
     'Dienstag',
@@ -9,8 +9,8 @@ $days = array(
     'Donnerstag',
     'Freitag',
     'Samstag',
-);
-$months = array(
+];
+$months = [
     'Januar',
     'Februar',
     'März',
@@ -23,9 +23,9 @@ $months = array(
     'Oktober',
     'November',
     'Dezember',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'RRule kann nicht vollständig zu Text konvertiert werden.',
     'for %count% times' => '%count% Mal',
     'for one time' => 'einmal',
@@ -113,4 +113,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/el.php
+++ b/translations/el.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'Κυριακή',
     'Δευτέρα',
     'Τρίτη',
@@ -9,8 +9,8 @@ $days = array(
     'Πέμπτη',
     'Παρασκευή',
     'Σάββατο',
-);
-$months = array(
+];
+$months = [
     'Ιανουάριος',
     'Φεβρουάριος',
     'Μάρτιος',
@@ -23,8 +23,8 @@ $months = array(
     'Οκτώβριος',
     'Νοέμβριος',
     'Δεκέμβριος',
-);
-$months_genitive = array(
+];
+$months_genitive = [
     'Ιανουαρίου',
     'Φεβρουαρίου',
     'Μαρτίου',
@@ -37,9 +37,9 @@ $months_genitive = array(
     'Οκτωβρίου',
     'Νοεμβρίου',
     'Δεκεμβρίου',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Αδυναμία πλήρους μετατροπής αυτού του κανόνα rrule σε κείμενο.',
     'for %count% times' => 'για %count% φορές',
     'for one time' => 'για μία φορά',
@@ -107,4 +107,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/en.php
+++ b/translations/en.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'Sunday',
     'Monday',
     'Tuesday',
@@ -9,8 +9,8 @@ $days = array(
     'Thursday',
     'Friday',
     'Saturday',
-);
-$months = array(
+];
+$months = [
     'January',
     'February',
     'March',
@@ -23,9 +23,9 @@ $months = array(
     'October',
     'November',
     'December',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Unable to fully convert this rrule to text.',
     'for %count% times' => 'for %count% times',
     'for one time' => 'once',
@@ -75,7 +75,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array('th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th');
+        $ends = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -101,4 +101,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/es.php
+++ b/translations/es.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'domingo',
     'lunes',
     'martes',
@@ -9,8 +9,8 @@ $days = array(
     'jueves',
     'viernes',
     'sábado',
-);
-$months = array(
+];
+$months = [
     'enero',
     'febrero',
     'marzo',
@@ -23,9 +23,9 @@ $months = array(
     'octubre',
     'noviembre',
     'diciembre',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'No se puede convertir completamente este RRULE al texto.',
     'for %count% times' => 'para %count% veces',
     'for one time' => 'por una vez',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array('a', 'a', 'nd', 'a', 'a', 'a', 'a', 'a', 'a', 'a');
+        $ends = ['a', 'a', 'nd', 'a', 'a', 'a', 'a', 'a', 'a', 'a'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/eu.php
+++ b/translations/eu.php
@@ -1,6 +1,6 @@
 <?php
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Ezin izan da rrule testura osoki bihurtu.',
     'for %count% times' => '%count% aldiz',
     'for %count% time' => '%count% aldia',
@@ -30,7 +30,7 @@ return array(
     'ordinal_number' => function ($str, $params) { // formats a number with a prefix e.g. every year on the 1st and 200th day
         $number = $params['number'];
 
-        $ends = array('garren', 'go', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren');
+        $ends = ['garren', 'go', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren', 'garren'];
 
         if (($number % 100) >= 11 && ($number % 100) <= 13) {
             $abbreviation = $number.'garren';
@@ -40,4 +40,4 @@ return array(
 
         return $abbreviation;
     },
-);
+];

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'dimanche',
     'lundi',
     'mardi',
@@ -9,8 +9,8 @@ $days = array(
     'jeudi',
     'vendredi',
     'samedi',
-);
-$months = array(
+];
+$months = [
     'janvier',
     'février',
     'mars',
@@ -23,9 +23,9 @@ $months = array(
     'octobre',
     'novembre',
     'décembre',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Cette règle de récurrence n\'a pas pu être convertie en texte.',
     'for %count% times' => '%count% fois',
     'for one time' => 'une fois',
@@ -100,4 +100,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/it.php
+++ b/translations/it.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'domenica',
     'lunedì',
     'martedì',
@@ -9,8 +9,8 @@ $days = array(
     'giovedì',
     'venerdì',
     'sabato',
-);
-$months = array(
+];
+$months = [
     'gennaio',
     'febbraio',
     'marzo',
@@ -23,9 +23,9 @@ $months = array(
     'ottobre',
     'novembre',
     'dicembre',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Non è possibile convertire questo rrule in testo.',
     'for %count% times' => 'per %count% volte',
     'for one time' => 'per una volta',
@@ -113,4 +113,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/nl.php
+++ b/translations/nl.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'zondag',
     'maandag',
     'dinsdag',
@@ -9,8 +9,8 @@ $days = array(
     'donderdag',
     'vrijdag',
     'zaterdag',
-);
-$months = array(
+];
+$months = [
     'januari',
     'februari',
     'maart',
@@ -23,9 +23,9 @@ $months = array(
     'oktober',
     'november',
     'december',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Unable to fully convert this rrule to text.',
     'for %count% times' => 'voor %count% keer',
     'for one time' => 'eenmalig',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array('ste', 'de', 'de', 'de', 'de', 'de', 'de', 'de', 'de', 'de');
+        $ends = ['ste', 'de', 'de', 'de', 'de', 'de', 'de', 'de', 'de', 'de'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/no.php
+++ b/translations/no.php
@@ -1,16 +1,16 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
-    'Søndag',
+$days = [
+    'Sï¿½ndag',
     'Mandag',
     'Tirsdag',
     'Onsdag',
     'Torsdag',
     'Fredag',
-    'Lørdag',
-);
-$months = array(
+    'Lï¿½rdag',
+];
+$months = [
     'Januar',
     'Februar',
     'Mars',
@@ -23,9 +23,9 @@ $months = array(
     'Oktober',
     'November',
     'Desember',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Kunne ikke konvertere rrule til tekst.',
     'for %count% times' => '%count% ganger',
     'for one time' => 'en gang',
@@ -43,16 +43,16 @@ return array(
     'or' => 'eller',
     'in_month' => 'i', // e.g. weekly in January, May and August
     'in_week' => 'i', // e.g. yearly in week 3
-    'on' => 'på', // e.g. every day on Tuesday, Wednesday and Friday
+    'on' => 'pï¿½', // e.g. every day on Tuesday, Wednesday and Friday
     'the_for_monthday' => 'den', // e.g. monthly on Tuesday the 1st
     'the_for_weekday' => 'den', // e.g. monthly on the 4th Monday
-    'on the' => 'på den', // e.g. every year on the 1st and 200th day
-    'of_the_month' => 'i måneden', // e.g. every year on the 2nd or 3rd of the month
-    'every %count% years' => 'hvert %count% år',
-    'every year' => 'årlig',
+    'on the' => 'pï¿½ den', // e.g. every year on the 1st and 200th day
+    'of_the_month' => 'i mï¿½neden', // e.g. every year on the 2nd or 3rd of the month
+    'every %count% years' => 'hvert %count% ï¿½r',
+    'every year' => 'ï¿½rlig',
     'every_month_list' => 'hver', // e.g. every January, May and August
-    'every %count% months' => 'hver %count% måned',
-    'every month' => 'månedlig',
+    'every %count% months' => 'hver %count% mï¿½ned',
+    'every month' => 'mï¿½nedlig',
     'every %count% weeks' => 'hver %count% uke',
     'every week' => 'ukentlig',
     'every %count% days' => 'hver %count% dag',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array('th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th');
+        $ends = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/pt-br.php
+++ b/translations/pt-br.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'domingo',
     'segunda-feira',
     'terça-feira',
@@ -9,8 +9,8 @@ $days = array(
     'quinta-feira',
     'sexta-feira',
     'sábado',
-);
-$months = array(
+];
+$months = [
     'Janeiro',
     'Fevereiro',
     'Março',
@@ -23,9 +23,9 @@ $months = array(
     'Outubro',
     'Novembro',
     'Dezembro',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Não foi possível converter esta regra para texto.',
     'for %count% times' => 'por %count% vezes',
     'for one time' => 'uma vez',
@@ -84,4 +84,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/sv.php
+++ b/translations/sv.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'Söndag',
     'Måndag',
     'Tisdag',
@@ -9,8 +9,8 @@ $days = array(
     'Torsdag',
     'Fredag',
     'Lördag',
-);
-$months = array(
+];
+$months = [
     'Januari',
     'Februari',
     'Mars',
@@ -23,9 +23,9 @@ $months = array(
     'Oktober',
     'November',
     'December',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Kunde inte konvertera denna rrule till text.',
     'for %count% times' => '%count% gånger',
     'for one time' => 'en gång',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array(':e', ':a', ':a', ':e', ':e', ':e', ':e', ':e', ':e', ':e');
+        $ends = [':e', ':a', ':a', ':e', ':e', ':e', ':e', ':e', ':e', ':e'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];

--- a/translations/tr.php
+++ b/translations/tr.php
@@ -1,7 +1,7 @@
 <?php
 
 // sunday first as date('w') is zero-based on sunday
-$days = array(
+$days = [
     'Pazar',
     'Pazartesi',
     'Salı',
@@ -9,8 +9,8 @@ $days = array(
     'Perşembe',
     'Cuma',
     'Cumartesi',
-);
-$months = array(
+];
+$months = [
     'Ocak',
     'Şubat',
     'Mart',
@@ -23,9 +23,9 @@ $months = array(
     'Ekim',
     'Kasım',
     'Aralık',
-);
+];
 
-return array(
+return [
     'Unable to fully convert this rrule to text.' => 'Bu rrule tam metne dönüştürülemiyor.',
     'for %count% times' => '%count% kez',
     'for one time' => 'bir kere',
@@ -71,7 +71,7 @@ return array(
     'ordinal_number' => function ($str, $params) {
         $number = $params['number'];
 
-        $ends = array('th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th');
+        $ends = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
         $suffix = '';
 
         $isNegative = $number < 0;
@@ -97,4 +97,4 @@ return array(
 
         return $abbreviation . $suffix;
     },
-);
+];


### PR DESCRIPTION
I'm not sure if this library is still to be maintained, but it could use some updates.

- PHP >=8
- add PSR12 codestyle config
- parameter, property & return types
- stricter Rule as value object
- option to return dates on newline to adhere to RFC
- parse TZID from DTSTART/DTEND input