### PR TITLE
Convert locales to lowercase for file lookup

### DIFF
--- a/src/Recurr/Transformer/Translator.php
+++ b/src/Recurr/Transformer/Translator.php
@@ -8,9 +8,12 @@ class Translator implements TranslatorInterface
 
     public function __construct($locale = 'en', $fallbackLocale = 'en')
     {
-        $this->loadLocale($fallbackLocale);
-        if ($locale !== $fallbackLocale) {
-            $this->loadLocale($locale);
+        $lowercasedLocale = strtolower($locale);
+        $lowercasedFallbackLocale = strtolower($fallbackLocale);
+
+        $this->loadLocale($lowercasedFallbackLocale);
+        if ($lowercasedLocale !== $lowercasedFallbackLocale) {
+            $this->loadLocale($lowercasedLocale);
         }
     }
 


### PR DESCRIPTION
We tend to store our locales like `pt-BR`, which meant the file lookup didn't work.