### PR TITLE
Fix compatibility with PHP 8.4

### DIFF
--- a/src/Recurr/DateUtil.php
+++ b/src/Recurr/DateUtil.php
@@ -111,8 +111,8 @@ class DateUtil
     public static function getDaySetOfWeek(
         \DateTimeInterface $dt,
         \DateTimeInterface $start,
-        Rule $rule = null,
-        DateInfo $dtInfo = null
+        ?Rule $rule = null,
+        ?DateInfo $dtInfo = null
     )
     {
         $start = clone $dt;

--- a/src/Recurr/Recurrence.php
+++ b/src/Recurr/Recurrence.php
@@ -27,7 +27,7 @@ class Recurrence
     /** @var int */
     protected $index;
 
-    public function __construct(\DateTimeInterface $start = null, \DateTimeInterface $end = null, $index = 0)
+    public function __construct(?\DateTimeInterface $start = null, ?\DateTimeInterface $end = null, $index = 0)
     {
         if ($start instanceof \DateTimeInterface) {
             $this->setStart($start);

--- a/src/Recurr/Transformer/ArrayTransformer.php
+++ b/src/Recurr/Transformer/ArrayTransformer.php
@@ -52,7 +52,7 @@ class ArrayTransformer
      *
      * @param ArrayTransformerConfig $config
      */
-    public function __construct(ArrayTransformerConfig $config = null)
+    public function __construct(?ArrayTransformerConfig $config = null)
     {
         if (!$config instanceof ArrayTransformerConfig) {
             $config = new ArrayTransformerConfig();
@@ -83,7 +83,7 @@ class ArrayTransformer
      * @return RecurrenceCollection|Recurrence[]
      * @throws InvalidWeekday
      */
-    public function transform(Rule $rule, ConstraintInterface $constraint = null, $countConstraintFailures = true)
+    public function transform(Rule $rule, ?ConstraintInterface $constraint = null, $countConstraintFailures = true)
     {
         $start = $rule->getStartDate();
         $end   = $rule->getEndDate();

--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -9,7 +9,7 @@ class TextTransformer
     protected $fragments = array();
     protected $translator;
 
-    public function __construct(TranslatorInterface $translator = null)
+    public function __construct(?TranslatorInterface $translator = null)
     {
         $this->translator = $translator ?: new Translator('en');
     }


### PR DESCRIPTION
Recently released new PHP 8.4 deprecates implicit nullable parameter definition - eg. float $start = null must be changed to ?float $start = null.

Nullable typehints are are supported since PHP 7.1, so that should be in line with minimum required version in composer.json