### PR TITLE
fix: cast $diff->days to int

### DIFF
--- a/src/Recurr/DateUtil.php
+++ b/src/Recurr/DateUtil.php
@@ -119,7 +119,7 @@ class DateUtil
         $start = $start->setDate($start->format('Y'), 1, 1);
 
         $diff  = $dt->diff($start);
-        $start = $diff->days;
+        $start = (int) $diff->days;
 
         $set = array();
         for ($i = $start, $k = 0; $k < 7; $k++) {


### PR DESCRIPTION
Fix https://github.com/simshaun/recurr/issues/218

Sometimes `$diff->days` value returns a boolean which causes an exception error on [line 126](https://github.com/simshaun/recurr/blob/master/src/Recurr/DateUtil.php#L122) because it's trying to increment a boolean.

This happens while using Carbon v3

```php
$diff  = $dt->diff($start);
$start = $diff->days;

$set = array();
for ($i = $start, $k = 0; $k < 7; $k++) {
    $set[] = $i;
    ++$i; // Increment on type bool has no effect, this will change in the next major version of PHP

    if (null !== $dtInfo && null !== $rule && $dtInfo->wDayMask[$i] == $rule->getWeekStartAsNum()) {
        break;
    }
}
```