### PR TITLE
TextTransformer: Allow yearly and weekly rules without a start date

### DIFF
--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -96,6 +96,7 @@ class TextTransformer
         $byDay = $rule->getByDay();
         $byYearDay = $rule->getByYearDay();
         $byWeekNum = $rule->getByWeekNumber();
+        $startDate = $rule->getStartDate();
 
         if (!empty($byMonth) && count($byMonth) > 1 && $interval == 1) {
             $this->addFragment($this->translator->trans('every_month_list'));
@@ -104,11 +105,11 @@ class TextTransformer
         }
 
         $hasNoOrOneByMonth = is_null($byMonth) || count($byMonth) <= 1;
-        if ($hasNoOrOneByMonth && empty($byMonthDay) && empty($byDay) && empty($byYearDay) && empty($byWeekNum)) {
+        if ($hasNoOrOneByMonth && empty($byMonthDay) && empty($byDay) && empty($byYearDay) && empty($byWeekNum) && $startDate !== null) {
             $this->addFragment($this->translator->trans('on'));
-            $monthNum = (is_array($byMonth) && count($byMonth)) ? $byMonth[0] : $rule->getStartDate()->format('n');
+            $monthNum = (is_array($byMonth) && count($byMonth)) ? $byMonth[0] : $startDate->format('n');
             $this->addFragment(
-                $this->translator->trans('day_month', array('month' => $monthNum, 'day' => $rule->getStartDate()->format('d')))
+                $this->translator->trans('day_month', array('month' => $monthNum, 'day' => $startDate->format('d')))
             );
         } elseif (!empty($byMonth)) {
             if ($interval != 1) {

--- a/src/Recurr/Transformer/TextTransformer.php
+++ b/src/Recurr/Transformer/TextTransformer.php
@@ -278,9 +278,11 @@ class TextTransformer
 
     protected function addDayOfWeek(Rule $rule)
     {
-        $this->addFragment($this->translator->trans('on'));
-        $dayNames = $this->translator->trans('day_names');
-        $this->addFragment($dayNames[$rule->getStartDate()->format('w')]);
+        if ($rule->getStartDate() !== null) {
+            $this->addFragment($this->translator->trans('on'));
+            $dayNames = $this->translator->trans('day_names');
+            $this->addFragment($dayNames[$rule->getStartDate()->format('w')]);
+        }
     }
 
     public function getByMonthAsText($byMonth)


### PR DESCRIPTION
The following code would not work. It would throw `Fatal error: Uncaught Error: Call to a member function format() on null in /srv/www/Projekte/Web/mms-web/vendor/simshaun/recurr/src/Recurr/Transformer/TextTransformer.php:110 `:
```PHP
$textTransformer = new TextTransformer();
echo $textTransformer->transform(new Rule('FREQ=YEARLY'));
```
It will only work with and additional BYDAY, BYMONTHDAY,... or a start date in the Rule. However, I think it makes sense to be able to retrieve the text "yearly" for the above Rule. (As returned for the "daily", "monthly" or "hourly" rule without start date.)

The same applies to "weekly".

I added a simple check to fix the PHP error.