### PR TITLE
Fix PHP 8.4 deprecation warning

### DIFF
--- a/src/Recurr/DateUtil.php
+++ b/src/Recurr/DateUtil.php
@@ -119,7 +119,7 @@ class DateUtil
         $start = $start->setDate($start->format('Y'), 1, 1);
 
         $diff  = $dt->diff($start);
-        $start = $diff->days;
+        $start = (int) $diff->days;
 
         $set = array();
         for ($i = $start, $k = 0; $k < 7; $k++) {


### PR DESCRIPTION
I tried to create tests that would trigger the deprecation warning I was getting, but couldn't reproduce the warning during test