### PR TITLE
Update ArrayCollection link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ print_r($transformer->transform($rule, $constraint));
     2014-06-01 startsBetween(2014-06-01, 2014-06-20) // false
     2014-06-01 startsBetween(2014-06-01, 2014-06-20, true) // true
 
-> Note: `RecurrenceCollection` extends the Doctrine project's [ArrayCollection](https://github.com/doctrine/collections/blob/master/lib/Doctrine/Common/Collections/ArrayCollection.php) class.
+> Note: `RecurrenceCollection` extends the Doctrine project's [ArrayCollection](https://github.com/doctrine/collections/blob/2.3.x/src/ArrayCollection.php) class.
 
 RRULE to Text
 --------------------------


### PR DESCRIPTION

- Updates the link to `ArrayCollection` as it resulted in a 404.

Before:
<img width="1288" height="674" alt="Screenshot 2025-10-02 at 11 00 24" src="https://github.com/user-attachments/assets/4ab519e9-ae61-4c10-b935-4e27d1392b05" />

After:
<img width="1254" height="645" alt="Screenshot 2025-10-02 at 11 02 03" src="https://github.com/user-attachments/assets/c2d14ff7-ee1a-4090-823c-a80f6dae764c" />
